### PR TITLE
[pure-refactor] Make everything incremental, fix custom version bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple wrapper around GraalVM tooling that will download and locally cache a G
 available select parts of the GraalVM compiler for use in Gradle builds.
 
 To use this plugin, apply `com.palantir.graal`. See a full example in the
-[integration tests](src/test/groovy/com/palantir/gradle/graal/GradleGraalPluginIntegrationSpec.groovy).
+[ETE tests](src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy).
 
 Gradle Tasks
 ------------

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ dependencies {
 
     testCompile gradleTestKit()
     testCompile 'com.netflix.nebula:nebula-test'
+    testCompile 'com.squareup.okhttp3:mockwebserver'
 
     baseline 'com.palantir.baseline:gradle-baseline-java-config:0.26.1@zip'
 }
@@ -95,7 +96,7 @@ tasks.withType(JavaCompile) {
 gradlePlugin {
     // do not add new task to publish to plugins.gradle.org
     automatedPublishing = false
-    
+
     plugins {
         graal {
             id = 'com.palantir.graal'

--- a/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
@@ -66,9 +66,17 @@ public class DownloadGraalTask extends DefaultTask {
         return graalVersion;
     }
 
+    public final void setGraalVersion(Provider<String> provider) {
+        graalVersion.set(provider);
+    }
+
     @Input
     public final Provider<String> getDownloadBaseUrl() {
         return downloadBaseUrl;
+    }
+
+    public final void setDownloadBaseUrl(Provider<String> provider) {
+        downloadBaseUrl.set(provider);
     }
 
     private Provider<Path> getCache() {
@@ -101,13 +109,5 @@ public class DownloadGraalTask extends DefaultTask {
             default:
                 throw new IllegalStateException("No GraalVM support for " + Platform.architecture());
         }
-    }
-
-    public void setGraalVersion(Provider<String> provider) {
-        graalVersion.set(provider);
-    }
-
-    public void setDownloadBaseUrl(Provider<String> provider) {
-        downloadBaseUrl.set(provider);
     }
 }

--- a/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
@@ -23,8 +23,8 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
@@ -36,17 +36,14 @@ public class DownloadGraalTask extends DefaultTask {
     private static final String ARTIFACT_PATTERN = "[url]/vm-[version]/graalvm-ce-[version]-[os]-[arch].tar.gz";
     private static final String FILENAME_PATTERN = "graalvm-ce-[version]-[arch].tar.gz";
 
-    private final Provider<String> graalVersion;
-    private final Provider<String> downloadBaseUrl;
+    private final Property<String> graalVersion = getProject().getObjects().property(String.class);
+    private final Property<String> downloadBaseUrl = getProject().getObjects().property(String.class);
 
-    @Inject
-    public DownloadGraalTask(GraalExtension extension) {
-        onlyIf(task -> !getTgz().get().exists());
+    public DownloadGraalTask() {
         setGroup(GradleGraalPlugin.TASK_GROUP);
         setDescription("Downloads and caches GraalVM binaries.");
 
-        graalVersion = extension.getGraalVersion();
-        downloadBaseUrl = extension.getDownloadBaseUrl();
+        onlyIf(task -> !getTgz().get().exists());
     }
 
     @TaskAction
@@ -103,5 +100,13 @@ public class DownloadGraalTask extends DefaultTask {
             default:
                 throw new IllegalStateException("No GraalVM support for " + Platform.architecture());
         }
+    }
+
+    public void setGraalVersion(Provider<String> provider) {
+        graalVersion.set(provider);
+    }
+
+    public void setDownloadBaseUrl(Provider<String> provider) {
+        downloadBaseUrl.set(provider);
     }
 }

--- a/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
@@ -53,8 +53,9 @@ public class DownloadGraalTask extends DefaultTask {
     public final void downloadGraal() throws IOException {
         Path cache = getCache().get();
         Files.createDirectories(cache);
-        InputStream in = new URL(render(ARTIFACT_PATTERN)).openStream();
-        Files.copy(in, getTgz().get().toPath(), StandardCopyOption.REPLACE_EXISTING);
+        try (InputStream in = new URL(render(ARTIFACT_PATTERN)).openStream()) {
+            Files.copy(in, getTgz().get().toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
     }
 
     @OutputFile

--- a/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
@@ -23,8 +23,8 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
@@ -36,13 +36,17 @@ public class DownloadGraalTask extends DefaultTask {
     private static final String ARTIFACT_PATTERN = "[url]/vm-[version]/graalvm-ce-[version]-[os]-[arch].tar.gz";
     private static final String FILENAME_PATTERN = "graalvm-ce-[version]-[arch].tar.gz";
 
-    private final Property<String> graalVersion = getProject().getObjects().property(String.class);
-    private final Property<String> downloadBaseUrl = getProject().getObjects().property(String.class);
+    private final Provider<String> graalVersion;
+    private final Provider<String> downloadBaseUrl;
 
-    public DownloadGraalTask() {
+    @Inject
+    public DownloadGraalTask(GraalExtension extension) {
         onlyIf(task -> !getTgz().get().exists());
         setGroup(GradleGraalPlugin.TASK_GROUP);
         setDescription("Downloads and caches GraalVM binaries.");
+
+        graalVersion = extension.getGraalVersion();
+        downloadBaseUrl = extension.getDownloadBaseUrl();
     }
 
     @TaskAction
@@ -63,17 +67,9 @@ public class DownloadGraalTask extends DefaultTask {
         return graalVersion;
     }
 
-    public final void setGraalVersion(Provider<String> value) {
-        graalVersion.set(value);
-    }
-
     @Input
     public final Provider<String> getDownloadBaseUrl() {
         return downloadBaseUrl;
-    }
-
-    public final void setDownloadBaseUrl(Provider<String> value) {
-        downloadBaseUrl.set(value);
     }
 
     private Provider<Path> getCache() {

--- a/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
@@ -16,7 +16,6 @@
 
 package com.palantir.gradle.graal;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -24,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
@@ -43,7 +43,7 @@ public class DownloadGraalTask extends DefaultTask {
         setGroup(GradleGraalPlugin.TASK_GROUP);
         setDescription("Downloads and caches GraalVM binaries.");
 
-        onlyIf(task -> !getTgz().get().exists());
+        onlyIf(task -> !getTgz().get().getAsFile().exists());
     }
 
     @TaskAction
@@ -51,13 +51,14 @@ public class DownloadGraalTask extends DefaultTask {
         Path cache = getCache().get();
         Files.createDirectories(cache);
         try (InputStream in = new URL(render(ARTIFACT_PATTERN)).openStream()) {
-            Files.copy(in, getTgz().get().toPath(), StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(in, getTgz().get().getAsFile().toPath(), StandardCopyOption.REPLACE_EXISTING);
         }
     }
 
     @OutputFile
-    public final Provider<File> getTgz() {
-        return getCache().map(cacheDir -> cacheDir.resolve(render(FILENAME_PATTERN)).toFile());
+    public final Provider<RegularFile> getTgz() {
+        return getProject().getLayout().file(
+                getCache().map(cacheDir -> cacheDir.resolve(render(FILENAME_PATTERN)).toFile()));
     }
 
     @Input

--- a/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
@@ -40,7 +40,7 @@ public class DownloadGraalTask extends DefaultTask {
     private final Property<String> downloadBaseUrl = getProject().getObjects().property(String.class);
 
     public DownloadGraalTask() {
-        getOutputs().upToDateWhen(task -> getTgz().get().exists());
+        onlyIf(task -> !getTgz().get().exists());
         setGroup(GradleGraalPlugin.TASK_GROUP);
         setDescription("Downloads and caches GraalVM binaries.");
     }

--- a/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
@@ -40,7 +40,7 @@ public class DownloadGraalTask extends DefaultTask {
     private final Property<String> downloadBaseUrl = getProject().getObjects().property(String.class);
 
     public DownloadGraalTask() {
-        onlyIf(task -> !getTgz().get().exists());
+        getOutputs().upToDateWhen(task -> getTgz().get().exists());
         setGroup(GradleGraalPlugin.TASK_GROUP);
         setDescription("Downloads and caches GraalVM binaries.");
     }

--- a/src/main/java/com/palantir/gradle/graal/ExtractGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/ExtractGraalTask.java
@@ -38,20 +38,20 @@ public class ExtractGraalTask extends DefaultTask {
     }
 
     @InputFile
-    public Provider<File> getInputTgz() {
+    public final Provider<File> getInputTgz() {
         return inputTgz;
     }
 
-    public void setInputTgz(Provider<File> value) {
+    public final void setInputTgz(Provider<File> value) {
         this.inputTgz.set(value);
     }
 
     @InputFile
-    public Provider<String> getGraalVersion() {
+    public final Provider<String> getGraalVersion() {
         return graalVersion;
     }
 
-    public void setGraalVersion(Provider<String> value) {
+    public final void setGraalVersion(Provider<String> value) {
         this.graalVersion.set(value);
     }
 

--- a/src/main/java/com/palantir/gradle/graal/ExtractGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/ExtractGraalTask.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.graal;
 
+import java.nio.file.Path;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
@@ -34,6 +35,7 @@ public class ExtractGraalTask extends DefaultTask {
     private final RegularFileProperty inputTgz = newInputFile();
     private final Property<String> graalVersion = getProject().getObjects().property(String.class);
     private final DirectoryProperty outputDirectory = newOutputDirectory();
+    private final Property<Path> cacheDir = getProject().getObjects().property(Path.class);
 
     public ExtractGraalTask() {
         setGroup(GradleGraalPlugin.TASK_GROUP);
@@ -42,7 +44,7 @@ public class ExtractGraalTask extends DefaultTask {
         onlyIf(task -> !getOutputDirectory().get().getAsFile().exists());
         outputDirectory.set(graalVersion.map(v ->
                 getProject().getLayout().getProjectDirectory()
-                        .dir(GradleGraalPlugin.CACHE_DIR.toFile().getAbsolutePath())
+                        .dir(cacheDir.get().toFile().getAbsolutePath())
                         .dir(v)
                         .dir("graalvm-ce-" + v)));
     }
@@ -57,7 +59,7 @@ public class ExtractGraalTask extends DefaultTask {
         getProject().exec(spec -> {
             spec.executable("tar");
             spec.args("-xzf", inputTgz.get().getAsFile().getAbsolutePath());
-            spec.workingDir(GradleGraalPlugin.CACHE_DIR.resolve(graalVersion.get()));
+            spec.workingDir(cacheDir.get().resolve(graalVersion.get()));
         });
     }
 
@@ -82,5 +84,9 @@ public class ExtractGraalTask extends DefaultTask {
     @OutputDirectory
     public final Provider<Directory> getOutputDirectory() {
         return outputDirectory;
+    }
+
+    final void setCacheDir(Path value) {
+        cacheDir.set(value);
     }
 }

--- a/src/main/java/com/palantir/gradle/graal/ExtractGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/ExtractGraalTask.java
@@ -19,18 +19,41 @@ package com.palantir.gradle.graal;
 import java.io.File;
 import java.nio.file.Path;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.specs.Spec;
-import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
 /** Extracts GraalVM tooling from downloaded tgz archive using the system's tar command. */
 public class ExtractGraalTask extends DefaultTask {
 
-    @Input private Provider<File> inputTgz;
-    @Input private Provider<String> graalVersion;
+    private final Property<File> inputTgz = getProject().getObjects().property(File.class);
+    private final Property<String> graalVersion = getProject().getObjects().property(String.class);
+
+    public ExtractGraalTask() {
+        onlyIf(task -> !getOutputDirectory().toFile().exists());
+        setGroup(GradleGraalPlugin.TASK_GROUP);
+        setDescription("Extracts GraalVM tooling from downloaded tgz archive using the system's tar command.");
+    }
+
+    @InputFile
+    public Provider<File> getInputTgz() {
+        return inputTgz;
+    }
+
+    public void setInputTgz(Provider<File> value) {
+        this.inputTgz.set(value);
+    }
+
+    @InputFile
+    public Provider<String> getGraalVersion() {
+        return graalVersion;
+    }
+
+    public void setGraalVersion(Provider<String> value) {
+        this.graalVersion.set(value);
+    }
 
     @TaskAction
     public final void extractGraal() {
@@ -49,26 +72,5 @@ public class ExtractGraalTask extends DefaultTask {
     @OutputDirectory
     public final Path getOutputDirectory() {
         return GradleGraalPlugin.CACHE_DIR.resolve(graalVersion.get()).resolve("graalvm-ce-" + graalVersion.get());
-    }
-
-    @Override
-    public final Spec<? super TaskInternal> getOnlyIf() {
-        return spec -> !getOutputDirectory().toFile().exists();
-    }
-
-    @Override
-    public final String getGroup() {
-        return GradleGraalPlugin.TASK_GROUP;
-    }
-
-    @Override
-    public final String getDescription() {
-        return "Extracts GraalVM tooling from downloaded tgz archive using the system's tar command.";
-    }
-
-    @SuppressWarnings("checkstyle:hiddenfield")
-    public final void configure(Provider<File> inputTgz, Provider<String> graalVersion) {
-        this.inputTgz = inputTgz;
-        this.graalVersion = graalVersion;
     }
 }

--- a/src/main/java/com/palantir/gradle/graal/ExtractGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/ExtractGraalTask.java
@@ -18,6 +18,7 @@ package com.palantir.gradle.graal;
 
 import java.io.File;
 import java.nio.file.Path;
+import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -30,12 +31,15 @@ import org.gradle.api.tasks.TaskAction;
 public class ExtractGraalTask extends DefaultTask {
 
     private final Property<File> inputTgz = getProject().getObjects().property(File.class);
-    private final Property<String> graalVersion = getProject().getObjects().property(String.class);
+    private final Provider<String> graalVersion;
 
-    public ExtractGraalTask() {
+    @Inject
+    public ExtractGraalTask(GraalExtension extension) {
         onlyIf(task -> !getOutputDirectory().toFile().exists());
         setGroup(GradleGraalPlugin.TASK_GROUP);
         setDescription("Extracts GraalVM tooling from downloaded tgz archive using the system's tar command.");
+
+        graalVersion = extension.getGraalVersion();
     }
 
     @InputFile
@@ -50,10 +54,6 @@ public class ExtractGraalTask extends DefaultTask {
     @Input
     public final Provider<String> getGraalVersion() {
         return graalVersion;
-    }
-
-    public final void setGraalVersion(Provider<String> value) {
-        this.graalVersion.set(value);
     }
 
     @TaskAction

--- a/src/main/java/com/palantir/gradle/graal/ExtractGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/ExtractGraalTask.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
@@ -46,7 +47,7 @@ public class ExtractGraalTask extends DefaultTask {
         this.inputTgz.set(value);
     }
 
-    @InputFile
+    @Input
     public final Provider<String> getGraalVersion() {
         return graalVersion;
     }

--- a/src/main/java/com/palantir/gradle/graal/GraalExtension.java
+++ b/src/main/java/com/palantir/gradle/graal/GraalExtension.java
@@ -26,10 +26,10 @@ public class GraalExtension {
     private static final String DEFAULT_DOWNLOAD_BASE_URL = "https://github.com/oracle/graal/releases/download/";
     private static final String DEFAULT_GRAAL_VERSION = "1.0.0-rc6";
 
-    private Property<String> downloadBaseUrl;
-    private Property<String> graalVersion;
-    private Property<String> mainClass;
-    private Property<String> outputName;
+    private final Property<String> downloadBaseUrl;
+    private final Property<String> graalVersion;
+    private final Property<String> mainClass;
+    private final Property<String> outputName;
 
     public GraalExtension(Project project) {
         downloadBaseUrl = project.getObjects().property(String.class);

--- a/src/main/java/com/palantir/gradle/graal/GraalExtension.java
+++ b/src/main/java/com/palantir/gradle/graal/GraalExtension.java
@@ -86,7 +86,7 @@ public class GraalExtension {
      *
      * <p>Defaults to {@link #DEFAULT_GRAAL_VERSION}</p>
      */
-    public final Property<String> getGraalVersion() {
+    public final Provider<String> getGraalVersion() {
         return graalVersion;
     }
 

--- a/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
+++ b/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
@@ -43,7 +43,8 @@ import org.gradle.api.tasks.TaskProvider;
 public class GradleGraalPlugin implements Plugin<Project> {
 
     /** Location to cache downloaded and extracted GraalVM tooling. */
-    static final Path CACHE_DIR = Optional.ofNullable(Paths.get(System.getProperty("com.palantir.graal.cache.dir")))
+    static final Path CACHE_DIR = Optional.ofNullable(System.getProperty("com.palantir.graal.cache.dir"))
+            .map(Paths::get)
             .orElse(Paths.get(System.getProperty("user.home"), ".gradle", "caches", "com.palantir.graal"));
 
     static final String TASK_GROUP = "Graal";

--- a/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
+++ b/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
@@ -54,15 +54,16 @@ public class GradleGraalPlugin implements Plugin<Project> {
     public final void apply(Project project) {
         GraalExtension extension = project.getExtensions().create("graal", GraalExtension.class, project);
 
-        DownloadGraalTask downloadGraal = project.getTasks().create(
-                "downloadGraalTooling", DownloadGraalTask.class, task -> {
-                    task.configure(extension.getGraalVersion(), extension.getDownloadBaseUrl());
+        DownloadGraalTask downloadGraal = project.getTasks().create("downloadGraalTooling", DownloadGraalTask.class,
+                task -> {
+                    task.setDownloadBaseUrl(extension.getDownloadBaseUrl());
+                    task.setGraalVersion(extension.getGraalVersion());
                 });
 
-        ExtractGraalTask extractGraal = project.getTasks().create(
-                "extractGraalTooling", ExtractGraalTask.class, task -> {
+        ExtractGraalTask extractGraal = project.getTasks().create("extractGraalTooling", ExtractGraalTask.class,
+                task -> {
                     task.dependsOn(downloadGraal);
-                    task.configure(asProvider(() -> downloadGraal.getOutput().toFile()), extension.getGraalVersion());
+                    task.configure(asProvider(() -> downloadGraal.getOutput()), extension.getGraalVersion());
                 });
 
         project.getTasks().create("nativeImage", NativeImageTask.class, task -> {

--- a/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
+++ b/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
@@ -52,20 +52,27 @@ public class GradleGraalPlugin implements Plugin<Project> {
         GraalExtension extension = project.getExtensions().create("graal", GraalExtension.class, project);
 
         TaskProvider<DownloadGraalTask> downloadGraal = project.getTasks().register(
-                "downloadGraalTooling", DownloadGraalTask.class, extension);
+                "downloadGraalTooling",
+                DownloadGraalTask.class,
+                extension);
 
         TaskProvider<ExtractGraalTask> extractGraal = project.getTasks().register(
-                "extractGraalTooling", ExtractGraalTask.class, extension);
+                "extractGraalTooling",
+                ExtractGraalTask.class,
+                extension);
         extractGraal.configure(task -> {
             task.dependsOn(downloadGraal);
             task.setInputTgz(downloadGraal.get().getTgz());
         });
 
         TaskProvider<NativeImageTask> nativeImage = project.getTasks().register(
-                "nativeImage", NativeImageTask.class, extension);
+                "nativeImage",
+                NativeImageTask.class,
+                extension,
+                project.getConfigurations().named("runtimeClasspath"),
+                project.getTasks().named("jar"));
         nativeImage.configure(task -> {
             task.dependsOn(extractGraal);
-            task.dependsOn("jar");
         });
     }
 }

--- a/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
+++ b/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
@@ -18,6 +18,7 @@ package com.palantir.gradle.graal;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.TaskProvider;
@@ -42,8 +43,8 @@ import org.gradle.api.tasks.TaskProvider;
 public class GradleGraalPlugin implements Plugin<Project> {
 
     /** Location to cache downloaded and extracted GraalVM tooling. */
-    static final Path CACHE_DIR =
-            Paths.get(System.getProperty("user.home"), ".gradle", "caches", "com.palantir.graal");
+    static final Path CACHE_DIR = Optional.ofNullable(Paths.get(System.getProperty("com.palantir.graal.cache.dir")))
+            .orElse(Paths.get(System.getProperty("user.home"), ".gradle", "caches", "com.palantir.graal"));
 
     static final String TASK_GROUP = "Graal";
 

--- a/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
+++ b/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
@@ -18,12 +18,8 @@ package com.palantir.gradle.graal;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.function.Supplier;
-import javax.annotation.Nullable;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Transformer;
-import org.gradle.api.provider.Provider;
 
 /**
  * Adds tasks to download, extract and interact with GraalVM tooling.
@@ -48,7 +44,7 @@ public class GradleGraalPlugin implements Plugin<Project> {
     public static final Path CACHE_DIR =
             Paths.get(System.getProperty("user.home"), ".gradle", "caches", "com.palantir.graal");
 
-    public static final String TASK_GROUP = "Graal";
+    static final String TASK_GROUP = "Graal";
 
     @Override
     public final void apply(Project project) {
@@ -67,40 +63,13 @@ public class GradleGraalPlugin implements Plugin<Project> {
                     task.setInputTgz(downloadGraal.getTgz());
                 });
 
-        project.getTasks().create("nativeImage", NativeImageTask.class, task -> {
-            task.dependsOn(extractGraal);
-            task.dependsOn("jar");
-            task.configure(extension.getMainClass(), extension.getOutputName(), extension.getGraalVersion());
-        });
-    }
-
-    private static <T> Provider<T> asProvider(Supplier<T> supplier) {
-        return new Provider<T>() {
-            @Override
-            public T get() {
-                return supplier.get();
-            }
-
-            @Nullable
-            @Override
-            public T getOrNull() {
-                return supplier.get();
-            }
-
-            @Override
-            public T getOrElse(T other) {
-                return supplier.get();
-            }
-
-            @Override
-            public <S> Provider<S> map(Transformer<? extends S, ? super T> transformer) {
-                return asProvider(() -> transformer.transform(get()));
-            }
-
-            @Override
-            public boolean isPresent() {
-                return true;
-            }
-        };
+        project.getTasks().register("nativeImage", NativeImageTask.class,
+                task -> {
+                    task.dependsOn(extractGraal);
+                    task.dependsOn("jar");
+                    task.setGraalVersion(extension.getGraalVersion());
+                    task.setMainClass(extension.getMainClass());
+                    task.setOutputName(extension.getOutputName());
+                });
     }
 }

--- a/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
+++ b/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
@@ -63,7 +63,8 @@ public class GradleGraalPlugin implements Plugin<Project> {
         ExtractGraalTask extractGraal = project.getTasks().create("extractGraalTooling", ExtractGraalTask.class,
                 task -> {
                     task.dependsOn(downloadGraal);
-                    task.configure(asProvider(() -> downloadGraal.getOutput()), extension.getGraalVersion());
+                    task.setGraalVersion(extension.getGraalVersion());
+                    task.setInputTgz(downloadGraal.getTgz());
                 });
 
         project.getTasks().create("nativeImage", NativeImageTask.class, task -> {

--- a/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
+++ b/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
@@ -42,13 +42,14 @@ import org.gradle.api.tasks.TaskProvider;
 public class GradleGraalPlugin implements Plugin<Project> {
 
     /** Location to cache downloaded and extracted GraalVM tooling. */
-    public static final Path CACHE_DIR =
+    static final Path CACHE_DIR =
             Paths.get(System.getProperty("user.home"), ".gradle", "caches", "com.palantir.graal");
 
     static final String TASK_GROUP = "Graal";
 
     @Override
     public final void apply(Project project) {
+        project.getPluginManager().apply("java");
         GraalExtension extension = project.getExtensions().create("graal", GraalExtension.class, project);
 
         TaskProvider<DownloadGraalTask> downloadGraal = project.getTasks().register(

--- a/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
+++ b/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
@@ -57,7 +57,10 @@ public class GradleGraalPlugin implements Plugin<Project> {
         TaskProvider<DownloadGraalTask> downloadGraal = project.getTasks().register(
                 "downloadGraalTooling",
                 DownloadGraalTask.class,
-                extension);
+                task -> {
+                    task.setGraalVersion(extension.getGraalVersion());
+                    task.setDownloadBaseUrl(extension.getDownloadBaseUrl());
+                });
 
         TaskProvider<ExtractGraalTask> extractGraal = project.getTasks().register(
                 "extractGraalTooling",

--- a/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
+++ b/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
@@ -65,11 +65,11 @@ public class GradleGraalPlugin implements Plugin<Project> {
         TaskProvider<ExtractGraalTask> extractGraal = project.getTasks().register(
                 "extractGraalTooling",
                 ExtractGraalTask.class,
-                extension);
-        extractGraal.configure(task -> {
-            task.dependsOn(downloadGraal);
-            task.setInputTgz(downloadGraal.get().getTgz());
-        });
+                task -> {
+                    task.setGraalVersion(extension.getGraalVersion());
+                    task.setInputTgz(downloadGraal.get().getTgz());
+                    task.dependsOn(downloadGraal);
+                });
 
         TaskProvider<NativeImageTask> nativeImage = project.getTasks().register(
                 "nativeImage",

--- a/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
+++ b/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
@@ -74,11 +74,13 @@ public class GradleGraalPlugin implements Plugin<Project> {
         TaskProvider<NativeImageTask> nativeImage = project.getTasks().register(
                 "nativeImage",
                 NativeImageTask.class,
-                extension,
                 project.getConfigurations().named("runtimeClasspath"),
                 project.getTasks().named("jar"));
         nativeImage.configure(task -> {
             task.dependsOn(extractGraal);
+            task.setMainClass(extension.getMainClass());
+            task.setOutputName(extension.getOutputName());
+            task.setGraalVersion(extension.getGraalVersion());
         });
     }
 }

--- a/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
+++ b/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
@@ -26,7 +26,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.RegularFile;
@@ -46,16 +45,14 @@ public class NativeImageTask extends DefaultTask {
     private final Property<String> mainClass = getProject().getObjects().property(String.class);
     private final Property<String> outputName = getProject().getObjects().property(String.class);
     private final Property<String> graalVersion = getProject().getObjects().property(String.class);
-    private final Provider<Configuration> classpath;
+    private final Property<Configuration> classpath = getProject().getObjects().property(Configuration.class);
     private final RegularFileProperty jarFile = newInputFile();
     private final RegularFileProperty outputFile = newOutputFile();
 
-    @Inject
-    public NativeImageTask(Provider<Configuration> classpath) {
+    public NativeImageTask() {
         setGroup(GradleGraalPlugin.TASK_GROUP);
         setDescription("Runs GraalVM's native-image command with configured options and parameters.");
 
-        this.classpath = classpath;
         this.outputFile.set(getProject().getLayout().getBuildDirectory()
                 .dir("graal")
                 .map(d -> d.file(outputName.get())));
@@ -160,12 +157,16 @@ public class NativeImageTask extends DefaultTask {
         return classpath;
     }
 
+    public final void setClasspath(Provider<Configuration> provider) {
+        classpath.set(provider);
+    }
+
     @InputFile
     public final Provider<RegularFile> getJarFiles() {
         return jarFile;
     }
 
-    public void setJarFile(Provider<File> provider) {
+    public final void setJarFile(Provider<File> provider) {
         jarFile.set(getProject().getLayout().file(provider));
     }
 

--- a/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
+++ b/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
@@ -109,29 +109,29 @@ public class NativeImageTask extends DefaultTask {
     }
 
     @Input
-    public Provider<String> getMainClass() {
+    public final Provider<String> getMainClass() {
         return mainClass;
     }
 
-    public void setMainClass(Provider<String> value) {
+    public final void setMainClass(Provider<String> value) {
         this.mainClass.set(value);
     }
 
     @Input
-    public Provider<String> getOutputName() {
+    public final Provider<String> getOutputName() {
         return outputName;
     }
 
-    public void setOutputName(Provider<String> value) {
+    public final void setOutputName(Provider<String> value) {
         this.outputName.set(value);
     }
 
     @Input
-    public Provider<String> getGraalVersion() {
+    public final Provider<String> getGraalVersion() {
         return graalVersion;
     }
 
-    public void setGraalVersion(Provider<String> value) {
+    public final void setGraalVersion(Provider<String> value) {
         this.graalVersion.set(value);
     }
 }

--- a/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
+++ b/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
@@ -66,13 +66,6 @@ public class NativeImageTask extends DefaultTask {
 
     @TaskAction
     public final void nativeImage() throws IOException {
-        if (!mainClass.isPresent()) {
-            throw new IllegalArgumentException("nativeImage requires graal.mainClass to be defined.");
-        }
-        if (!graalVersion.isPresent()) {
-            throw new IllegalStateException("nativeImage requires graal.version to be defined.");
-        }
-
         List<String> args = new ArrayList<>();
         args.add("-cp");
         args.add(generateClasspathArgument());

--- a/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
+++ b/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
@@ -31,6 +31,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
@@ -42,24 +43,22 @@ import org.gradle.jvm.tasks.Jar;
 /** Runs GraalVM's native-image command with configured options and parameters. */
 public class NativeImageTask extends DefaultTask {
 
-    private final Provider<String> mainClass;
-    private final Provider<String> outputName;
-    private final Provider<String> graalVersion;
+    private final Property<String> mainClass = getProject().getObjects().property(String.class);
+    private final Property<String> outputName = getProject().getObjects().property(String.class);
+    private final Property<String> graalVersion = getProject().getObjects().property(String.class);
     private final Provider<Configuration> classpath;
     private final Provider<Jar> jar;
     private final Provider<RegularFile> outputFile;
 
     @Inject
-    public NativeImageTask(GraalExtension extension, Provider<Configuration> classpath, Provider<Jar> jar) {
-        this.classpath = classpath;
-        this.jar = jar;
-        this.mainClass = extension.getMainClass();
-        this.outputName = extension.getOutputName();
-        this.graalVersion = extension.getGraalVersion();
-        this.outputFile = getProject().getLayout().getBuildDirectory().dir("graal").map(d -> d.file(outputName.get()));
-
+    public NativeImageTask(Provider<Configuration> classpath, Provider<Jar> jar) {
         setGroup(GradleGraalPlugin.TASK_GROUP);
         setDescription("Runs GraalVM's native-image command with configured options and parameters.");
+
+        this.classpath = classpath;
+        this.jar = jar;
+        this.outputFile = getProject().getLayout().getBuildDirectory().dir("graal").map(d -> d.file(outputName.get()));
+
         dependsOn(jar);
         doLast(t -> {
             getLogger().warn("native-image available at {} ({}MB)",
@@ -137,6 +136,10 @@ public class NativeImageTask extends DefaultTask {
         return mainClass;
     }
 
+    public final void setMainClass(Provider<String> provider) {
+        mainClass.set(provider);
+    }
+
     @Input
     public final Provider<String> getOutputName() {
         return outputName;
@@ -145,6 +148,10 @@ public class NativeImageTask extends DefaultTask {
     @Input
     public final Provider<String> getGraalVersion() {
         return graalVersion;
+    }
+
+    public final void setGraalVersion(Provider<String> provider) {
+        graalVersion.set(provider);
     }
 
     @InputFiles
@@ -161,5 +168,9 @@ public class NativeImageTask extends DefaultTask {
     @OutputFile
     public final Provider<RegularFile> getOutputFile() {
         return outputFile;
+    }
+
+    public final void setOutputName(Provider<String> provider) {
+        outputName.set(provider);
     }
 }

--- a/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
+++ b/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
@@ -149,17 +149,17 @@ public class NativeImageTask extends DefaultTask {
 
     @InputFiles
     @Classpath
-    public Provider<Configuration> getClasspath() {
+    public final Provider<Configuration> getClasspath() {
         return classpath;
     }
 
     @InputFiles
-    public Provider<FileCollection> getJarFiles() {
+    public final Provider<FileCollection> getJarFiles() {
         return jar.map(j -> j.getOutputs().getFiles());
     }
 
     @OutputFile
-    public Provider<RegularFile> getOutputFile() {
+    public final Provider<RegularFile> getOutputFile() {
         return outputFile;
     }
 }

--- a/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
+++ b/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
@@ -24,8 +24,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
@@ -33,13 +33,18 @@ import org.gradle.api.tasks.TaskAction;
 /** Runs GraalVM's native-image command with configured options and parameters. */
 public class NativeImageTask extends DefaultTask {
 
-    private final Property<String> mainClass = getProject().getObjects().property(String.class);
-    private final Property<String> outputName = getProject().getObjects().property(String.class);
-    private final Property<String> graalVersion = getProject().getObjects().property(String.class);
+    private final Provider<String> mainClass;
+    private final Provider<String> outputName;
+    private final Provider<String> graalVersion;
 
-    public NativeImageTask() {
+    @Inject
+    public NativeImageTask(GraalExtension extension) {
         setGroup(GradleGraalPlugin.TASK_GROUP);
         setDescription("Runs GraalVM's native-image command with configured options and parameters.");
+
+        mainClass = extension.getMainClass();
+        outputName = extension.getOutputName();
+        graalVersion = extension.getGraalVersion();
     }
 
     @TaskAction
@@ -113,25 +118,13 @@ public class NativeImageTask extends DefaultTask {
         return mainClass;
     }
 
-    public final void setMainClass(Provider<String> value) {
-        this.mainClass.set(value);
-    }
-
     @Input
     public final Provider<String> getOutputName() {
         return outputName;
     }
 
-    public final void setOutputName(Provider<String> value) {
-        this.outputName.set(value);
-    }
-
     @Input
     public final Provider<String> getGraalVersion() {
         return graalVersion;
-    }
-
-    public final void setGraalVersion(Provider<String> value) {
-        this.graalVersion.set(value);
     }
 }

--- a/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
+++ b/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
@@ -100,10 +100,10 @@ public class NativeImageTask extends DefaultTask {
 
     private String getExecutable() {
         return GradleGraalPlugin.CACHE_DIR
-                    .resolve(Paths.get(graalVersion.get(), "graalvm-ce-" + graalVersion.get()))
-                    .resolve(getArchitectureSpecifiedBinaryPath())
-                    .toFile()
-                    .getAbsolutePath();
+                .resolve(Paths.get(graalVersion.get(), "graalvm-ce-" + graalVersion.get()))
+                .resolve(getArchitectureSpecifiedBinaryPath())
+                .toFile()
+                .getAbsolutePath();
     }
 
     private String generateClasspathArgument() {

--- a/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
+++ b/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
@@ -32,9 +33,14 @@ import org.gradle.api.tasks.TaskAction;
 /** Runs GraalVM's native-image command with configured options and parameters. */
 public class NativeImageTask extends DefaultTask {
 
-    @Input private Provider<String> mainClass;
-    @Input private Provider<String> outputName;
-    @Input private Provider<String> graalVersion;
+    private final Property<String> mainClass = getProject().getObjects().property(String.class);
+    private final Property<String> outputName = getProject().getObjects().property(String.class);
+    private final Property<String> graalVersion = getProject().getObjects().property(String.class);
+
+    public NativeImageTask() {
+        setGroup(GradleGraalPlugin.TASK_GROUP);
+        setDescription("Runs GraalVM's native-image command with configured options and parameters.");
+    }
 
     @TaskAction
     public final void nativeImage() {
@@ -62,16 +68,6 @@ public class NativeImageTask extends DefaultTask {
             spec.executable(getExecutable(graalVersion.get()));
             spec.args(args);
         });
-    }
-
-    @Override
-    public final String getGroup() {
-        return GradleGraalPlugin.TASK_GROUP;
-    }
-
-    @Override
-    public final String getDescription() {
-        return "Runs GraalVM's native-image command with configured options and parameters.";
     }
 
     private String getOutputDirectory() {
@@ -103,14 +99,6 @@ public class NativeImageTask extends DefaultTask {
                 .collect(Collectors.joining(":"));
     }
 
-    @SuppressWarnings("checkstyle:hiddenfield")
-    public final void configure(Provider<String> mainClass, Provider<String> outputName,
-            Provider<String> graalVersion) {
-        this.mainClass = mainClass;
-        this.outputName = outputName;
-        this.graalVersion = graalVersion;
-    }
-
     private Path getArchitectureSpecifiedBinaryPath() {
         switch (Platform.operatingSystem()) {
             case MAC: return Paths.get("Contents", "Home", "bin", "native-image");
@@ -120,4 +108,30 @@ public class NativeImageTask extends DefaultTask {
         }
     }
 
+    @Input
+    public Provider<String> getMainClass() {
+        return mainClass;
+    }
+
+    public void setMainClass(Provider<String> value) {
+        this.mainClass.set(value);
+    }
+
+    @Input
+    public Provider<String> getOutputName() {
+        return outputName;
+    }
+
+    public void setOutputName(Provider<String> value) {
+        this.outputName.set(value);
+    }
+
+    @Input
+    public Provider<String> getGraalVersion() {
+        return graalVersion;
+    }
+
+    public void setGraalVersion(Provider<String> value) {
+        this.graalVersion.set(value);
+    }
 }

--- a/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
+++ b/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
@@ -48,6 +48,7 @@ public class NativeImageTask extends DefaultTask {
     private final Property<Configuration> classpath = getProject().getObjects().property(Configuration.class);
     private final RegularFileProperty jarFile = newInputFile();
     private final RegularFileProperty outputFile = newOutputFile();
+    private final Property<Path> cacheDir = getProject().getObjects().property(Path.class);
 
     public NativeImageTask() {
         setGroup(GradleGraalPlugin.TASK_GROUP);
@@ -88,7 +89,7 @@ public class NativeImageTask extends DefaultTask {
     }
 
     private String getExecutable() {
-        return GradleGraalPlugin.CACHE_DIR
+        return cacheDir.get()
                 .resolve(Paths.get(graalVersion.get(), "graalvm-ce-" + graalVersion.get()))
                 .resolve(getArchitectureSpecifiedBinaryPath())
                 .toFile()
@@ -170,5 +171,9 @@ public class NativeImageTask extends DefaultTask {
 
     public final void setOutputName(Provider<String> provider) {
         outputName.set(provider);
+    }
+
+    final void setCacheDir(Path value) {
+        cacheDir.set(value);
     }
 }

--- a/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
+++ b/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
@@ -31,6 +31,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Classpath;
@@ -48,7 +49,7 @@ public class NativeImageTask extends DefaultTask {
     private final Property<String> graalVersion = getProject().getObjects().property(String.class);
     private final Provider<Configuration> classpath;
     private final Provider<Jar> jar;
-    private final Provider<RegularFile> outputFile;
+    private final RegularFileProperty outputFile = newOutputFile();
 
     @Inject
     public NativeImageTask(Provider<Configuration> classpath, Provider<Jar> jar) {
@@ -57,7 +58,9 @@ public class NativeImageTask extends DefaultTask {
 
         this.classpath = classpath;
         this.jar = jar;
-        this.outputFile = getProject().getLayout().getBuildDirectory().dir("graal").map(d -> d.file(outputName.get()));
+        this.outputFile.set(getProject().getLayout().getBuildDirectory()
+                .dir("graal")
+                .map(d -> d.file(outputName.get())));
 
         dependsOn(jar);
         doLast(t -> {

--- a/src/main/resources/META-INF/gradle-plugins/com.palantir.graal.properties
+++ b/src/main/resources/META-INF/gradle-plugins/com.palantir.graal.properties
@@ -1,0 +1,1 @@
+implementation-class=com.palantir.gradle.graal.GradleGraalPlugin

--- a/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
@@ -40,6 +40,7 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         graal {
             mainClass 'com.palantir.test.Main'
             outputName 'hello-world'
+            graalVersion '1.0.0-rc5'
         }
         '''
 

--- a/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
@@ -26,7 +26,7 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         new File(getProjectDir(), "src/main/java/com/palantir/test").mkdirs()
         new File(getProjectDir(), "src/main/java/com/palantir/test/Main.java") << '''
         package com.palantir.test;
-        
+       
         public final class Main {
             public static final void main(String[] args) {
                 System.out.println("hello, world!");

--- a/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
@@ -23,8 +23,8 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
 
     def 'test default version nativeImage'() {
         setup:
-        new File(getProjectDir(), "src/main/java/com/palantir/test").mkdirs()
-        new File(getProjectDir(), "src/main/java/com/palantir/test/Main.java") << '''
+        directory("src/main/java/com/palantir/test")
+        file("src/main/java/com/palantir/test/Main.java") << '''
         package com.palantir.test;
        
         public final class Main {
@@ -74,7 +74,7 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
 
         then:
         println result3.standardOutput
-        result3.wasUpToDate(':nativeImage') == false
+        !result3.wasUpToDate(':nativeImage')
         output.getAbsolutePath().execute().text.equals("hello, world (modified)!\n")
     }
 }

--- a/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
@@ -1,0 +1,57 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.graal
+
+import nebula.test.IntegrationSpec
+import nebula.test.functional.ExecutionResult
+
+class GradleGraalEndToEndSpec extends IntegrationSpec {
+
+    def 'test default version nativeImage'() {
+        setup:
+        new File(getProjectDir(), "src/main/java/com/palantir/test").mkdirs()
+        new File(getProjectDir(), "src/main/java/com/palantir/test/Main.java") << '''
+            package com.palantir.test;
+
+        public final class Main {
+            public static final void main(String[] args) {
+                System.out.println("hello, world!");
+            }
+        }
+        '''
+
+        buildFile << '''
+        apply plugin: 'java'
+        apply plugin: 'com.palantir.graal'
+
+        graal {
+            mainClass 'com.palantir.test.Main'
+            outputName 'hello-world'
+        }
+        '''
+
+        when:
+        ExecutionResult result = runTasksSuccessfully('nativeImage') // note, this accesses your real ~/.gradle cache
+        println "Gradle Standard Out:\n" + result.standardOutput
+        println "Gradle Standard Error:\n" + result.standardError
+        File output = new File(getProjectDir(), "build/graal/hello-world");
+
+        then:
+        output.exists()
+        output.getAbsolutePath().execute().text.equals("hello, world!\n")
+    }
+}

--- a/src/test/groovy/com/palantir/gradle/graal/GradleGraalPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleGraalPluginIntegrationSpec.groovy
@@ -37,8 +37,8 @@ class GradleGraalPluginIntegrationSpec extends IntegrationSpec {
 
         fakeBaseUrl = String.format("http://localhost:%s/oracle/graal/releases/download/", server.getPort())
 
-        new File(getProjectDir(), "src/main/java/com/palantir/test").mkdirs()
-        new File(getProjectDir(), "src/main/java/com/palantir/test/Main.java") << '''
+        directory("src/main/java/com/palantir/test")
+        file("src/main/java/com/palantir/test/Main.java") << '''
             package com.palantir.test;
 
             public final class Main {
@@ -66,8 +66,8 @@ class GradleGraalPluginIntegrationSpec extends IntegrationSpec {
 
         then:
         result.wasExecuted(':downloadGraalTooling')
-        result.wasUpToDate(':downloadGraalTooling') == false
-        result.wasSkipped(':downloadGraalTooling') == false
+        !result.wasUpToDate(':downloadGraalTooling')
+        !result.wasSkipped(':downloadGraalTooling')
 
         server.takeRequest().requestUrl.toString() =~ "http://localhost:${server.port}" +
                 "/oracle/graal/releases/download//vm-1.0.0-rc3/graalvm-ce-1.0.0-rc3-(macos|linux)-amd64.tar.gz"

--- a/src/test/groovy/com/palantir/gradle/graal/GradleGraalPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleGraalPluginIntegrationSpec.groovy
@@ -92,8 +92,8 @@ class GradleGraalPluginIntegrationSpec extends IntegrationSpec {
         then:
         new File(folder.getRoot(),
                 ".gradle/caches/com.palantir.graal/1.0.0-rc5/graalvm-ce-1.0.0-rc5-amd64.tar.gz").text == '<<tgz>>'
-        server.takeRequest().requestUrl.toString() == "http://localhost:${server.port}" +
-                "/oracle/graal/releases/download//vm-1.0.0-rc5/graalvm-ce-1.0.0-rc5-macos-amd64.tar.gz"
+        server.takeRequest().requestUrl.toString() =~ "http://localhost:${server.port}" +
+                "/oracle/graal/releases/download//vm-1.0.0-rc5/graalvm-ce-1.0.0-rc5-(macos|linux)-amd64.tar.gz"
     }
 
     def 'downloadGraalTooling behaves incrementally'() {

--- a/src/test/groovy/com/palantir/gradle/graal/GradleGraalPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleGraalPluginIntegrationSpec.groovy
@@ -55,7 +55,7 @@ class GradleGraalPluginIntegrationSpec extends IntegrationSpec {
             apply plugin: 'com.palantir.graal'
 
             graal {
-               graalVersion '1.0.0-rc5'
+               graalVersion '1.0.0-rc3'
                downloadBaseUrl '${fakeBaseUrl}'
             }
         """
@@ -70,8 +70,8 @@ class GradleGraalPluginIntegrationSpec extends IntegrationSpec {
         result.wasSkipped(':downloadGraalTooling') == false
 
         server.takeRequest().requestUrl.toString() =~ "http://localhost:${server.port}" +
-                "/oracle/graal/releases/download//vm-1.0.0-rc5/graalvm-ce-1.0.0-rc5-(macos|linux)-amd64.tar.gz"
-        file("cacheDir/.gradle/caches/com.palantir.graal/1.0.0-rc5/graalvm-ce-1.0.0-rc5-amd64.tar.gz").exists()
+                "/oracle/graal/releases/download//vm-1.0.0-rc3/graalvm-ce-1.0.0-rc3-(macos|linux)-amd64.tar.gz"
+        file("cacheDir/1.0.0-rc3/graalvm-ce-1.0.0-rc3-amd64.tar.gz").text == '<<tgz>>'
     }
 
     def 'downloadGraalTooling behaves incrementally'() {
@@ -80,7 +80,6 @@ class GradleGraalPluginIntegrationSpec extends IntegrationSpec {
             apply plugin: 'com.palantir.graal'
 
             graal {
-               graalVersion '1.0.0-rc1'
                downloadBaseUrl '${fakeBaseUrl}'
             }
         """

--- a/src/test/groovy/com/palantir/gradle/graal/GradleGraalPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleGraalPluginIntegrationSpec.groovy
@@ -47,7 +47,6 @@ class GradleGraalPluginIntegrationSpec extends IntegrationSpec {
     def 'allows specifying different graal version'() {
         setup:
         buildFile << """
-            apply plugin: 'java'
             apply plugin: 'com.palantir.graal'
 
             graal {
@@ -71,7 +70,6 @@ class GradleGraalPluginIntegrationSpec extends IntegrationSpec {
     def 'downloadGraalTooling behaves incrementally'() {
         setup:
         buildFile << """
-            apply plugin: 'java'
             apply plugin: 'com.palantir.graal'
 
             graal {

--- a/src/test/groovy/com/palantir/gradle/graal/GradleGraalPluginProjectSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleGraalPluginProjectSpec.groovy
@@ -18,9 +18,6 @@ package com.palantir.gradle.graal
 
 import nebula.test.PluginProjectSpec
 
-/**
- * Tests for {@link GradleGraalPlugin}.
- */
 class GradleGraalPluginProjectSpec extends PluginProjectSpec {
 
     @Override

--- a/versions.props
+++ b/versions.props
@@ -1,1 +1,2 @@
 com.netflix.nebula:nebula-test = 6.7.1
+com.squareup.okhttp3:* = 3.11.0


### PR DESCRIPTION
Motivation: I want to make it easy to use jackson ObjectMappers to deserialize some conjure-generated aliases and Beans correctly.  I want a neat way to provide the [reflectconfig json file](https://github.com/oracle/graal/blob/master/substratevm/REFLECTION.md#manual-configuration) so started looking into adding a way to specify arguments. This PR is just a a pre-requisite of the real reflection work.

## Before this PR

- custom graalVersion did not work (only the initial version was plumbed through)
- The slow nativeImage task was not incremental
- tests could not run from Intellij
- plugin would break nastily if the 'java' plugin was not available

## After this PR

- We have an ETE test that verifies that setting a specific graal version in the extension propagates cleanly through the download, extract and nativeImage tasks
- Test proves nativeImage task is incremental
- Running tests from IntelliJ works
- automatically applies the java plugin
- uses [lazy configuration](https://docs.gradle.org/current/userguide/lazy_configuration.html) best practises to minimize configuration time overhead
