### PR TITLE
Allow specifying native-image options & new ./gradlew reflectionConfig task

### DIFF
--- a/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
+++ b/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
@@ -82,6 +82,9 @@ public class GradleGraalPlugin implements Plugin<Project> {
                 task -> {
                     task.add("java.util.ArrayList");
                     task.add("java.util.Optional");
+                    task.setFile(project.getLayout().getBuildDirectory()
+                            .dir("graal")
+                            .map(d -> d.file("reflectconfig.json")));
                 });
 
         TaskProvider<Jar> jar = project.getTasks().withType(Jar.class).named("jar");

--- a/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
+++ b/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
@@ -76,6 +76,14 @@ public class GradleGraalPlugin implements Plugin<Project> {
                     task.dependsOn(downloadGraal);
                 });
 
+        TaskProvider<ReflectionConfigTask> reflectionConfig = project.getTasks().register(
+                "reflectionConfig",
+                ReflectionConfigTask.class,
+                task -> {
+                    task.add("java.util.ArrayList");
+                    task.add("java.util.Optional");
+                });
+
         TaskProvider<Jar> jar = project.getTasks().withType(Jar.class).named("jar");
         project.getTasks().register(
                 "nativeImage",
@@ -87,8 +95,12 @@ public class GradleGraalPlugin implements Plugin<Project> {
                     task.setJarFile(jar.map(j -> j.getOutputs().getFiles().getSingleFile()));
                     task.setClasspath(project.getConfigurations().named("runtimeClasspath"));
                     task.setCacheDir(cacheDir);
+                    task.option(reflectionConfig.get().getOutputJsonFile()
+                            .map(file -> "-H:ReflectionConfigurationFiles=" + file));
+
                     task.dependsOn(extractGraal);
                     task.dependsOn(jar);
+                    task.dependsOn(reflectionConfig);
                 });
     }
 }

--- a/src/main/java/com/palantir/gradle/graal/NativeImageOptions.java
+++ b/src/main/java/com/palantir/gradle/graal/NativeImageOptions.java
@@ -51,6 +51,8 @@ public final class NativeImageOptions implements Serializable {
         list.add(option);
     }
 
+    // TODO(dfox): make the incremental behaviour here understand when a file has changed or not
+
     public Provider<List<String>> getProvider() {
         return list.map(providers -> providers.stream().flatMap(object -> {
 

--- a/src/main/java/com/palantir/gradle/graal/NativeImageOptions.java
+++ b/src/main/java/com/palantir/gradle/graal/NativeImageOptions.java
@@ -1,0 +1,69 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.graal;
+
+import static java.util.stream.Collectors.toList;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.stream.Stream;
+import org.gradle.api.Project;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Provider;
+
+/**
+ * See substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java in
+ * https://github.com/oracle/graal/.
+ */
+public final class NativeImageOptions implements Serializable {
+    private static final long serialVersionUID = 9307652985066589L;
+
+    // using Object to represent String | Provider<String>
+    private final ListProperty<Object> list;
+
+    public NativeImageOptions(Project project) {
+        list = project.getObjects().listProperty(Object.class);
+    }
+
+    public List<String> get() {
+        return getProvider().get();
+    }
+
+    public void set(String option) {
+        list.add(option);
+    }
+
+    public void set(Provider<String> option) {
+        list.add(option);
+    }
+
+    public Provider<List<String>> getProvider() {
+        return list.map(providers -> providers.stream().flatMap(object -> {
+
+            if (object instanceof Provider) {
+                Provider provider = (Provider) object;
+                return provider.isPresent() ? Stream.of((String) provider.get()) : Stream.empty();
+            }
+
+            if (object instanceof String) {
+                return Stream.of((String) object);
+            }
+
+            throw new IllegalStateException("list elements must be either String or Provider<String>, was: " + object);
+        }).collect(toList()));
+    }
+}

--- a/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
+++ b/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
@@ -141,6 +141,11 @@ public class NativeImageTask extends DefaultTask {
     }
 
     @Input
+    public final Provider<String> getOutputName() {
+        return outputName;
+    }
+
+    @Input
     public final Provider<String> getGraalVersion() {
         return graalVersion;
     }

--- a/src/main/java/com/palantir/gradle/graal/ReflectionConfigTask.java
+++ b/src/main/java/com/palantir/gradle/graal/ReflectionConfigTask.java
@@ -52,7 +52,7 @@ public class ReflectionConfigTask extends DefaultTask {
     public final void generateFile() throws IOException {
         List<Map<String, Object>> json = classes.get().stream()
                 .map(clazz -> {
-                    LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+                    Map<String, Object> map = new LinkedHashMap<>();
                     map.put("name", clazz);
                     map.put("allDeclaredConstructors", true);
                     map.put("allPublicConstructors", true);

--- a/src/main/java/com/palantir/gradle/graal/ReflectionConfigTask.java
+++ b/src/main/java/com/palantir/gradle/graal/ReflectionConfigTask.java
@@ -1,0 +1,95 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.graal;
+
+import static java.util.stream.Collectors.toList;
+
+import groovy.json.JsonOutput;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+public class ReflectionConfigTask extends DefaultTask {
+
+    private final RegularFileProperty file = newOutputFile();
+    private final ListProperty<String> classes = getProject().getObjects().listProperty(String.class);
+
+    public ReflectionConfigTask() {
+        setGroup(GradleGraalPlugin.TASK_GROUP);
+        setDescription("Generates a reflectconfig.json file based on supplied class names");
+
+        file.set(new File(getProject().getBuildDir(), "graal/reflectconfig.json"));
+        onlyIf(t -> classes.isPresent() && !classes.get().isEmpty());
+    }
+
+    @TaskAction
+    public final void generateFile() throws IOException {
+        List<Map<String, Object>> json = classes.get().stream()
+                .map(clazz -> {
+                    LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+                    map.put("name", clazz);
+                    map.put("allDeclaredConstructors", true);
+                    map.put("allPublicConstructors", true);
+                    map.put("allDeclaredMethods", true);
+                    map.put("allPublicMethods", true);
+                    map.put("allDeclaredFields", true);
+                    map.put("allPublicFields", true);
+                    return map;
+                })
+                .collect(toList());
+
+        String string = JsonOutput.prettyPrint(JsonOutput.toJson(json));
+        Files.write(file.get().getAsFile().toPath(), string.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Input
+    public final Provider<List<String>> getClasses() {
+        return classes;
+    }
+
+    @OutputFile
+    public final RegularFileProperty getOutputJsonFile() {
+        return file;
+    }
+
+    public final void setFile(File file) {
+        this.file.set(file);
+    }
+
+    public final void add(String string) {
+        classes.add(string);
+    }
+
+    public final void add(Provider<String> value) {
+        classes.add(value);
+    }
+
+    public final void addAll(String... strings) {
+        classes.addAll(strings);
+    }
+}

--- a/src/main/java/com/palantir/gradle/graal/ReflectionConfigTask.java
+++ b/src/main/java/com/palantir/gradle/graal/ReflectionConfigTask.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
@@ -34,6 +35,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
+// TODO(dfox): make this read files containing class names
 public class ReflectionConfigTask extends DefaultTask {
 
     private final RegularFileProperty file = newOutputFile();
@@ -43,7 +45,6 @@ public class ReflectionConfigTask extends DefaultTask {
         setGroup(GradleGraalPlugin.TASK_GROUP);
         setDescription("Generates a reflectconfig.json file based on supplied class names");
 
-        file.set(new File(getProject().getBuildDir(), "graal/reflectconfig.json"));
         onlyIf(t -> classes.isPresent() && !classes.get().isEmpty());
     }
 
@@ -77,8 +78,12 @@ public class ReflectionConfigTask extends DefaultTask {
         return file;
     }
 
-    public final void setFile(File file) {
-        this.file.set(file);
+    public final void setFile(File value) {
+        file.set(value);
+    }
+
+    public final void setFile(Provider<RegularFile> regularFileProvider) {
+        file.set(regularFileProvider);
     }
 
     public final void add(String string) {

--- a/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
@@ -42,6 +42,10 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
             outputName 'hello-world'
             graalVersion '1.0.0-rc5'
         }
+        
+        nativeImage {
+            option '-H:Optimize=1'
+        }
         '''
 
         when:


### PR DESCRIPTION
## Before this PR

This plugin couldn't be used to create native images for anything that involves Jackson.

The `-H:ReflectionConfigurationFiles=/path/to/reflectconfig` is necessary to make Jackson deserialization work, but there was no way to specify any kind of extra options to the `native-image` invocation.

## After this PR

You can now create native-images that use ObjectMappers, `@JsonPropery` annotations etc etc 🎉🎉🎉

People can add arbitrary options, e.g.:

```gradle 
        nativeImage {
            option '-H:Optimize=1'
        }
```

Also, you can run `./gradlew reflectionConfig` to generate the necessary JSON from some given class names:

```json
[
  {
    "name" : "java.lang.Class",
    "allDeclaredConstructors" : true,
    "allPublicConstructors" : true,
    "allDeclaredMethods" : true,
    "allPublicMethods" : true
  }
]
```

fixes https://github.com/palantir/gradle-graal/issues/15