### PR TITLE
Add support for building shared libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Configure this plugin and its wrappers around GraalVM tools through the `graal` 
 
 **`native-image` controls**
 * `outputName`: the name to use for the image output
-* `mainClass`: the main class entry-point for the image to run
+* `mainClass`: (optional) the main class entry-point for the image to run; if absent, the `nativeImage` task builds a shared library instead of an executable
 * `option`: additional native-image options `https://github.com/oracle/graal/blob/master/substratevm/OPTIONS.md`
 
 Local GraalVM Tooling Cache

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Configure this plugin and its wrappers around GraalVM tools through the `graal` 
 
 **`native-image` controls**
 * `outputName`: the name to use for the image output
-* `mainClass`: (optional) the main class entry-point for the image to run; if absent, the `nativeImage` task builds a shared library instead of an executable
+* `mainClass`: (optional) the main class entry-point for the image to run; if absent, then adding the `--shared` option (see below) results in the `nativeImage` task building a shared library instead of an executable
 * `option`: additional native-image options `https://github.com/oracle/graal/blob/master/substratevm/OPTIONS.md`
 
 Local GraalVM Tooling Cache

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,6 @@ dependencies {
     testCompile gradleTestKit()
     testCompile 'com.netflix.nebula:nebula-test'
     testCompile 'com.squareup.okhttp3:mockwebserver'
-
 }
 
 dependencyRecommendations {

--- a/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
@@ -165,7 +165,7 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
 
         when:
         runTasksSuccessfully('nativeImage')
-        File dylibFile = new File(getProjectDir(), "build/graal/hello-world.dylib")
+        File dylibFile = new File(getProjectDir(), "build/graal/hello-world.so")
 
         then:
         dylibFile.exists()

--- a/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
@@ -48,7 +48,7 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         ExecutionResult result = runTasksSuccessfully('nativeImage') // note, this accesses your real ~/.gradle cache
         println "Gradle Standard Out:\n" + result.standardOutput
         println "Gradle Standard Error:\n" + result.standardError
-        File output = new File(getProjectDir(), "build/graal/hello-world");
+        File output = new File(getProjectDir(), "build/graal/hello-world")
 
         then:
         output.exists()
@@ -116,7 +116,7 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         ExecutionResult result = runTasks('nativeImage') // note, this accesses your real ~/.gradle cache
         println "Gradle Standard Out:\n" + result.standardOutput
         println "Gradle Standard Error:\n" + result.standardError
-        File output = new File(getProjectDir(), "build/graal/hello-world");
+        File output = new File(getProjectDir(), "build/graal/hello-world")
 
         then:
         output.exists()
@@ -143,5 +143,31 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
 
         then:
         result.standardOutput.contains("Use 'outputName' instead of")
+    }
+
+    def 'can build shared libraries'() {
+        setup:
+        directory("src/main/java/com/palantir/test")
+        file("src/main/java/com/palantir/test/Main.java") << '''
+        package com.palantir.test;
+
+        public final class Main {}
+        '''
+        buildFile << '''
+        apply plugin: 'com.palantir.graal'
+
+        graal {
+            outputName 'hello-world'
+            graalVersion '1.0.0-rc5'
+            option '--shared'
+        }
+        '''
+
+        when:
+        runTasksSuccessfully('nativeImage')
+        File dylibFile = new File(getProjectDir(), "build/graal/hello-world.dylib")
+
+        then:
+        dylibFile.exists()
     }
 }

--- a/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
@@ -16,6 +16,9 @@
 
 package com.palantir.gradle.graal
 
+import static com.palantir.gradle.graal.Platform.OperatingSystem.LINUX
+import static com.palantir.gradle.graal.Platform.OperatingSystem.MAC
+
 import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
 
@@ -45,7 +48,8 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         '''
 
         when:
-        ExecutionResult result = runTasksSuccessfully('nativeImage') // note, this accesses your real ~/.gradle cache
+        ExecutionResult result = runTasksSuccessfully('nativeImage')
+        // note, this accesses your real ~/.gradle cache
         println "Gradle Standard Out:\n" + result.standardOutput
         println "Gradle Standard Error:\n" + result.standardError
         File output = new File(getProjectDir(), "build/graal/hello-world")
@@ -113,7 +117,8 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         '''
 
         when:
-        ExecutionResult result = runTasks('nativeImage') // note, this accesses your real ~/.gradle cache
+        ExecutionResult result = runTasks('nativeImage')
+        // note, this accesses your real ~/.gradle cache
         println "Gradle Standard Out:\n" + result.standardOutput
         println "Gradle Standard Error:\n" + result.standardError
         File output = new File(getProjectDir(), "build/graal/hello-world")
@@ -137,7 +142,8 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         '''
 
         when:
-        ExecutionResult result = runTasksWithFailure('nativeImage') // note, this accesses your real ~/.gradle cache
+        ExecutionResult result = runTasksWithFailure('nativeImage')
+        // note, this accesses your real ~/.gradle cache
         println "Gradle Standard Out:\n" + result.standardOutput
         println "Gradle Standard Error:\n" + result.standardError
 
@@ -165,9 +171,20 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
 
         when:
         runTasksSuccessfully('nativeImage')
-        File dylibFile = new File(getProjectDir(), "build/graal/hello-world.so")
+        File dylibFile = new File(getProjectDir(), "build/graal/hello-world." + getSharedLibPrefixByOs())
 
         then:
         dylibFile.exists()
+    }
+
+    def getSharedLibPrefixByOs() {
+        switch (Platform.operatingSystem()) {
+            case MAC:
+                return "dylib"
+            case LINUX:
+                return "so"
+            default:
+                throw new IllegalStateException("No GraalVM support for " + Platform.operatingSystem())
+        }
     }
 }


### PR DESCRIPTION
When the `mainClass` configuration parameter is omitted then the
nativeImage task builds a shared library.