### PR TITLE
Upgrade the default graal version to 1.0-RC12 (was 1.0-RC11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Configuration
 Configure this plugin and its wrappers around GraalVM tools through the `graal` extension with the following options:
 
 **General GraalVM controls**
-* `graalVersion`: the version string to use when downloading GraalVM (defaults to `1.0.0-rc11`)
+* `graalVersion`: the version string to use when downloading GraalVM (defaults to `1.0.0-rc12`)
 * `downloadBaseUrl`: the base download URL to use (defaults to `https://github.com/oracle/graal/releases/download/`)
 
 **`native-image` controls**

--- a/src/main/java/com/palantir/gradle/graal/GraalExtension.java
+++ b/src/main/java/com/palantir/gradle/graal/GraalExtension.java
@@ -27,7 +27,7 @@ import org.gradle.api.provider.Provider;
 public class GraalExtension {
 
     private static final String DEFAULT_DOWNLOAD_BASE_URL = "https://github.com/oracle/graal/releases/download/";
-    private static final String DEFAULT_GRAAL_VERSION = "1.0.0-rc11";
+    private static final String DEFAULT_GRAAL_VERSION = "1.0.0-rc12";
 
     private final Property<String> downloadBaseUrl;
     private final Property<String> graalVersion;


### PR DESCRIPTION
Release notes:
https://www.graalvm.org/docs/release-notes/#10-rc12