### PR TITLE
Always set output name parameter last

### DIFF
--- a/src/main/java/com/palantir/gradle/graal/BaseGraalCompileTask.java
+++ b/src/main/java/com/palantir/gradle/graal/BaseGraalCompileTask.java
@@ -78,12 +78,15 @@ public class BaseGraalCompileTask extends DefaultTask {
         args.add("-cp");
         args.add(generateClasspathArgument());
         args.add("-H:Path=" + maybeCreateOutputDirectory().getAbsolutePath());
-        if (outputName.isPresent()) {
-            args.add("-H:Name=" + outputName.get());
-        }
         if (options.isPresent()) {
             List<String> optionList = options.get();
             args.addAll(optionList);
+        }
+        // Set H:Name after all other options in order to override other H:Name
+        // options that were expanded from macro options above. See
+        // https://github.com/oracle/graal/issues/1032
+        if (outputName.isPresent()) {
+            args.add("-H:Name=" + outputName.get());
         }
     }
 


### PR DESCRIPTION
The native-image binary supports "macro" options that can expand to
several other options. For instance, the `--language` option also sets
the `H:Name` option, thus overriding any earlier `H:Name` paramters.
After this change, we always set the `H:Name` option last so that the
Gradle configuration for `outputName` wins.