### PR TITLE
[updated] Changed artifact download URL pattern to match the new GraalVM CE release 19.0.0 TGZ file name standard

### DIFF
--- a/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
@@ -33,11 +33,12 @@ import org.gradle.api.tasks.TaskAction;
 /** Downloads GraalVM binaries. */
 public class DownloadGraalTask extends DefaultTask {
 
-    private static final String ARTIFACT_PATTERN_RC_VERSION = "[url]/vm-[version]/graalvm-ce-[version]-[os]-[arch].tar.gz";
-    private static final String ARTIFACT_PATTERN_RELEASE_VERSION = "[url]/vm-[version]/graalvm-ce-[os]-[arch]-[version].tar.gz";
-    
-    private static final String FILENAME_PATTERN_RC_VERSION = "graalvm-ce-[version]-[arch].tar.gz";
-    private static final String FILENAME_PATTERN_RELEASE_VERSION = "graalvm-ce-[os]-[arch]-[version].tar.gz";
+    private static final String ARTIFACT_PATTERN_RC_VERSION
+            = "[url]/vm-[version]/graalvm-ce-[version]-[os]-[arch].tar.gz";
+    private static final String ARTIFACT_PATTERN_RELEASE_VERSION
+            = "[url]/vm-[version]/graalvm-ce-[os]-[arch]-[version].tar.gz";
+
+    private static final String FILENAME_PATTERN = "graalvm-ce-[version]-[arch].tar.gz";
 
     private final Property<String> graalVersion = getProject().getObjects().property(String.class);
     private final Property<String> downloadBaseUrl = getProject().getObjects().property(String.class);
@@ -54,22 +55,19 @@ public class DownloadGraalTask extends DefaultTask {
     public final void downloadGraal() throws IOException {
         Path cache = getCacheSubdirectory().get();
         Files.createDirectories(cache);
-        
-        final String artefactPattern = isGraalRcVersion() ? 
-            ARTIFACT_PATTERN_RC_VERSION : ARTIFACT_PATTERN_RELEASE_VERSION;
-        
-        try (InputStream in = new URL(render(artefactPattern)).openStream()) {
+
+        final String artifactPattern = isGraalRcVersion()
+                ? ARTIFACT_PATTERN_RC_VERSION : ARTIFACT_PATTERN_RELEASE_VERSION;
+
+        try (InputStream in = new URL(render(artifactPattern)).openStream()) {
             Files.copy(in, getTgz().get().getAsFile().toPath(), StandardCopyOption.REPLACE_EXISTING);
         }
     }
 
     @OutputFile
     public final Provider<RegularFile> getTgz() {
-        final String filenamePattern = isGraalRcVersion() ? 
-            FILENAME_PATTERN_RC_VERSION : FILENAME_PATTERN_RELEASE_VERSION;
-        
         return getProject().getLayout()
-                .file(getCacheSubdirectory().map(dir -> dir.resolve(render(filenamePattern)).toFile()));
+                .file(getCacheSubdirectory().map(dir -> dir.resolve(render(FILENAME_PATTERN)).toFile()));
     }
 
     @Input
@@ -121,7 +119,7 @@ public class DownloadGraalTask extends DefaultTask {
                 throw new IllegalStateException("No GraalVM support for " + Platform.architecture());
         }
     }
-    
+
     private boolean isGraalRcVersion() {
         return graalVersion.get().startsWith("1.0.0-rc");
     }


### PR DESCRIPTION
From #104

> As of version 19.0.0 GraalVM team has changed the way the distro file is named in the GitHub download page for its Community Edition. Most notable is the change to the order of [version], [os] and [arch] as well as the use of "darwin" instead of "macos" for MacOS builds.

See #104 for context.

This adds a small commit with the following changes:
* Format DownloadGraalTask
* Fix spelling: artefact->artifact
* Revert to single FILENAME_PATTERN