### PR TITLE
Add Windows support

### DIFF
--- a/src/main/java/com/palantir/gradle/graal/BaseGraalCompileTask.java
+++ b/src/main/java/com/palantir/gradle/graal/BaseGraalCompileTask.java
@@ -230,7 +230,7 @@ public abstract class BaseGraalCompileTask extends DefaultTask {
 
     /*
      This regex basically means:
-     - from the start (^), find the first occurence of "REG_" after some other stuff (.+?, + = one or more, ? = lazy)
+     - from the start (^), find the first occurrence of "REG_" after some other stuff (.+?, + = one or more, ? = lazy)
      - keep going as long it's not whitespace (\S)
      - hop over all the whitespace (\s)
      - read the rest of the line until the end ($) into group 1 (the parens)

--- a/src/main/java/com/palantir/gradle/graal/BaseGraalCompileTask.java
+++ b/src/main/java/com/palantir/gradle/graal/BaseGraalCompileTask.java
@@ -16,14 +16,19 @@
 
 package com.palantir.gradle.graal;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
@@ -37,9 +42,10 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
+import org.gradle.process.ExecSpec;
 
 
-public class BaseGraalCompileTask extends DefaultTask {
+public abstract class BaseGraalCompileTask extends DefaultTask {
     private final Property<String> outputName = getProject().getObjects().property(String.class);
     private final ListProperty<String> options = getProject().getObjects().listProperty(String.class);
     private final RegularFileProperty outputFile = getProject().getObjects().fileProperty();
@@ -52,8 +58,10 @@ public class BaseGraalCompileTask extends DefaultTask {
         setGroup(GradleGraalPlugin.TASK_GROUP);
         this.outputFile.set(getProject().getLayout().getBuildDirectory()
                 .dir("graal")
-                .map(d -> d.file(outputName.get())));
+                .map(d -> d.file(outputName.get() + getArchitectureSpecifiedOutputExtension())));
     }
+
+    protected abstract String getArchitectureSpecifiedOutputExtension();
 
     protected final File maybeCreateOutputDirectory() throws IOException {
         File directory = getOutputFile().get().getAsFile().getParentFile();
@@ -96,15 +104,203 @@ public class BaseGraalCompileTask extends DefaultTask {
         classpathArgument.addAll(classpath.get().getFiles());
         classpathArgument.add(jarFile.getAsFile().get());
 
-        return classpathArgument.stream().map(File::getAbsolutePath).collect(Collectors.joining(":"));
+        return classpathArgument.stream()
+            .map(File::getAbsolutePath)
+            .collect(Collectors.joining(getArchitectureSpecifiedPathSeparator()));
     }
 
     private Path getArchitectureSpecifiedBinaryPath() {
         switch (Platform.operatingSystem()) {
             case MAC: return Paths.get("Contents", "Home", "bin", "native-image");
             case LINUX: return Paths.get("bin", "native-image");
+            case WINDOWS: return Paths.get("bin", "native-image.cmd");
             default:
                 throw new IllegalStateException("No GraalVM support for " + Platform.operatingSystem());
+        }
+    }
+
+    private String getArchitectureSpecifiedPathSeparator() {
+        switch (Platform.operatingSystem()) {
+            case MAC:
+            case LINUX:
+                return ":";
+            case WINDOWS:
+                return ";";
+            default:
+                throw new IllegalStateException("No GraalVM support for " + Platform.operatingSystem());
+        }
+    }
+
+    protected final void configurePlatformSpecifics(ExecSpec spec) {
+        if (Platform.operatingSystem() == Platform.OperatingSystem.WINDOWS) {
+            // on Windows the native-image executable needs to be launched from the Windows SDK Command Prompt
+            // this is mentioned at https://github.com/oracle/graal/tree/master/substratevm#quick-start
+            // all this does though, is setting a bunch of environment variables
+            // the main ones are set here to avoid the need for running inside the Windows SDK Command Prompt
+            // reference (with installed SDK): C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd
+            // assuming x64 as current and target cpu
+
+            String programFilesx86 = System.getenv("ProgramFiles(x86)");
+            String programFiles = System.getenv("ProgramFiles");
+            String winDir = System.getenv("WinDir");
+            String path = System.getenv("Path");
+
+            String regKeyPath = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\VisualStudio\\SxS\\VC7";
+            String frameworkDir32 = winDir + "\\Microsoft.NET\\Framework\\";
+            String frameworkDir64 = readWindowsRegistryString(regKeyPath, "FrameworkDir64");
+            String frameworkVer32 = readWindowsRegistryString(regKeyPath, "FrameworkVer32");
+            String frameworkVer64 = readWindowsRegistryString(regKeyPath, "FrameworkVer64");
+
+            String frameworkDir = frameworkDir32;
+            String frameworkVersion = frameworkVer32;
+
+            if (frameworkDir64 != null && new File(frameworkDir64).exists()) {
+                frameworkDir = frameworkDir64;
+                frameworkVersion = frameworkVer64;
+            }
+
+            regKeyPath = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\VisualStudio\\SxS\\VC7";
+            String vcInstallDir = readWindowsRegistryString(regKeyPath, "10.0");
+            if (vcInstallDir == null) {
+                vcInstallDir = programFilesx86 + "\\Microsoft Visual Studio 10.0\\VC\\";
+            }
+
+            String vsRegKeyPath = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\VisualStudio\\SxS\\VS7";
+            String vsInstallDir = readWindowsRegistryString(vsRegKeyPath, "10.0");
+            if (vsInstallDir == null) {
+                vsInstallDir = programFilesx86 + "\\Microsoft Visual Studio 10.0\\";
+            }
+
+            String envCl = "/AI " + frameworkDir + "\\" + frameworkVersion;
+            getLogger().debug("[env] CL: {}", envCl);
+            spec.environment("CL", envCl);
+
+            String vcTools = vcInstallDir + "Bin";
+
+            String winSdkRegKeyPath = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows\\v7.1";
+            String windowsSdkDir = readWindowsRegistryString(winSdkRegKeyPath, "InstallationFolder");
+            if (windowsSdkDir == null) {
+                windowsSdkDir = programFiles + "%ProgramFiles%\\Microsoft SDKs\\Windows\\v7.1\\";
+            }
+
+            // current_cpu: x64, target_cpu: x64
+            vcTools = vcTools + "\\amd64;" + vcTools + "\\VCPackages;";
+            String sdkTools = windowsSdkDir + "Bin\\NETFX 4.0 Tools\\x64;"
+                    + windowsSdkDir + "Bin\\x64;"
+                    + windowsSdkDir + "Bin;";
+            String fxTools = frameworkDir64 + "\\" + frameworkVersion + ";"
+                    + frameworkDir32 + frameworkVersion + ";"
+                    + winDir + "\\Microsoft.NET\\Framework64\\v3.5;"
+                    + winDir + "\\Microsoft.NET\\Framework\\v3.5;";
+
+            String vsTools = vsInstallDir + "Common7\\IDE;" + vsInstallDir + "Common7\\Tools;";
+
+            String envPath = fxTools + ";" + vsTools + ";" + vcTools + ";" + sdkTools + ";" + path;
+            getLogger().debug("[env] PATH: {}", envPath);
+            spec.environment("PATH", envPath);
+
+            String vcLibraries = vcInstallDir + "Lib";
+            String vcIncludes = vcInstallDir + "INCLUDE";
+            String osLibraries = windowsSdkDir + "Lib";
+            String osIncludes = windowsSdkDir + "INCLUDE;" + windowsSdkDir + "INCLUDE\\gl";
+
+            String envLib = vcLibraries + "\\amd64;" + osLibraries + "\\X64";
+            String envLibPath = fxTools + ";" + vcLibraries + "\\amd64";
+            String envInclude = vcIncludes + ";" + osIncludes;
+
+            if (new File(vcInstallDir, "ATLMFC").exists()) {
+                envInclude += ";" + vcInstallDir + "ATLMFC\\INCLUDE";
+                envLib += ";" + vcInstallDir + "ATLMFC\\LIB";
+            }
+
+            getLogger().debug("[env] LIB: {}", envLib);
+            spec.environment("LIB", envLib);
+
+            getLogger().debug("[env] LIBPATH: {}", envLibPath);
+            spec.environment("LIBPATH", envLibPath);
+
+            getLogger().debug("[env] INCLUDE: {}", envInclude);
+            spec.environment("INCLUDE", envInclude);
+
+            String envAppVer = "6.1";
+            getLogger().debug("[env] APPVER: {}", envAppVer);
+            spec.environment("APPVER", envAppVer);
+        }
+    }
+
+    /*
+     This regex basically means:
+     - from the start (^), find the first occurence of "REG_" after some other stuff (.+?, + = one or more, ? = lazy)
+     - keep going as long it's not whitespace (\S)
+     - hop over all the whitespace (\s)
+     - read the rest of the line until the end ($) into group 1 (the parens)
+
+     Note that this fails, if the name contains "REG_", but it's ok here, since such keys aren't queried.
+     */
+    private static final Pattern regValueLine = Pattern.compile("^.+?REG_\\S+\\s+(.*)$");
+
+    private String readWindowsRegistryString(String key, String name) {
+        // launch: reg query <key> /v <name>
+        ProcessBuilder procBuilder = new ProcessBuilder(
+                "C:\\Windows\\System32\\reg.exe", "query", key, "/v", name);
+        Process proc;
+        try {
+            proc = procBuilder.start();
+        } catch (IOException e) {
+            throw new RuntimeException("Error querying windows registry: couldn't launch reg.exe", e);
+        }
+
+        /* example output:
+        cmd> reg query HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\SxS\VC7 /v FrameworkDir64
+
+        HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\SxS\VC7
+            FrameworkDir64    REG_SZ    C:\WINDOWS\Microsoft.NET\Framework64
+
+         */
+        BufferedReader reader = new BufferedReader(new InputStreamReader(proc.getInputStream()));
+
+        // find the first line that contains some non-whitespace and starts with whitespace
+        Optional<String> firstValueLine = reader.lines()
+                .filter(line -> line.trim().length() > 0 && line.matches("^\\s+.+$"))
+                .findFirst();
+
+        // wait for the process to finish
+        try {
+            proc.waitFor();
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Error querying windows registry: thread was interrupted.", e);
+        }
+
+        try {
+            reader.close();
+        } catch (IOException e) {
+            throw new RuntimeException("Error querying windows registry: stream couldn't be closed.", e);
+        }
+
+        int exitValue = proc.exitValue();
+        if (exitValue == 1 || !firstValueLine.isPresent()) {
+            // key or name was not found
+            getLogger().debug("[registry] {} -> {} = not found (exit code: {})", key, name, exitValue);
+            return null;
+        }
+
+        String line = firstValueLine.get();
+        Matcher matcher = regValueLine.matcher(line);
+        if (!matcher.find()) {
+            getLogger().error("[registry] unexpected line format:\n{}", line);
+            throw new RuntimeException("Error querying windows registry: unexpected line format.");
+        }
+
+        String value = matcher.group(1);
+        getLogger().debug("[registry] {} -> {} = {}", key, name, value);
+        return value;
+    }
+
+    protected static long fileSizeMegabytes(RegularFile regularFile) {
+        try {
+            return Files.size(regularFile.getAsFile().toPath()) / (1000 * 1000);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/com/palantir/gradle/graal/BaseGraalCompileTask.java
+++ b/src/main/java/com/palantir/gradle/graal/BaseGraalCompileTask.java
@@ -16,18 +16,15 @@
 
 package com.palantir.gradle.graal;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.gradle.api.DefaultTask;
@@ -136,95 +133,29 @@ public abstract class BaseGraalCompileTask extends DefaultTask {
             // on Windows the native-image executable needs to be launched from the Windows SDK Command Prompt
             // this is mentioned at https://github.com/oracle/graal/tree/master/substratevm#quick-start
             // all this does though, is setting a bunch of environment variables
-            // the main ones are set here to avoid the need for running inside the Windows SDK Command Prompt
-            // reference (with installed SDK): C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd
-            // assuming x64 as current and target cpu
 
-            String programFilesx86 = System.getenv("ProgramFiles(x86)");
-            String programFiles = System.getenv("ProgramFiles");
-            String winDir = System.getenv("WinDir");
-            String path = System.getenv("Path");
-
-            String regKeyPath = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\VisualStudio\\SxS\\VC7";
-            String frameworkDir32 = winDir + "\\Microsoft.NET\\Framework\\";
-            String frameworkDir64 = readWindowsRegistryString(regKeyPath, "FrameworkDir64");
-            String frameworkVer32 = readWindowsRegistryString(regKeyPath, "FrameworkVer32");
-            String frameworkVer64 = readWindowsRegistryString(regKeyPath, "FrameworkVer64");
-
-            String frameworkDir = frameworkDir32;
-            String frameworkVersion = frameworkVer32;
-
-            if (frameworkDir64 != null && new File(frameworkDir64).exists()) {
-                frameworkDir = frameworkDir64;
-                frameworkVersion = frameworkVer64;
+            String cmdContent = "@echo off\r\n" +
+                    "call \"C:\\Program Files\\Microsoft SDKs\\Windows\\v7.1\\Bin\\SetEnv.cmd\"\r\n" +
+                    "\"" + spec.getExecutable() + "\"" + spec.getArgs().stream().collect(Collectors.joining(" ", " ", "\r\n"));
+            Path startCmd = getProject().getBuildDir().toPath().resolve("tmp").resolve("com.palantir.graal").resolve("start-executable.cmd");
+            try {
+                if (!Files.exists(startCmd.getParent())) {
+                    Files.createDirectories(startCmd.getParent());
+                }
+                Files.write(startCmd, cmdContent.getBytes("utf-8"));
+            } catch (IOException e) {
+                // "utf-8" is always known
             }
 
-            regKeyPath = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\VisualStudio\\SxS\\VC7";
-            String vcInstallDir = readWindowsRegistryString(regKeyPath, "10.0");
-            if (vcInstallDir == null) {
-                vcInstallDir = programFilesx86 + "\\Microsoft Visual Studio 10.0\\VC\\";
-            }
-
-            String vsRegKeyPath = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\VisualStudio\\SxS\\VS7";
-            String vsInstallDir = readWindowsRegistryString(vsRegKeyPath, "10.0");
-            if (vsInstallDir == null) {
-                vsInstallDir = programFilesx86 + "\\Microsoft Visual Studio 10.0\\";
-            }
-
-            String envCl = "/AI " + frameworkDir + "\\" + frameworkVersion;
-            getLogger().debug("[env] CL: {}", envCl);
-            spec.environment("CL", envCl);
-
-            String vcTools = vcInstallDir + "Bin";
-
-            String winSdkRegKeyPath = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows\\v7.1";
-            String windowsSdkDir = readWindowsRegistryString(winSdkRegKeyPath, "InstallationFolder");
-            if (windowsSdkDir == null) {
-                windowsSdkDir = programFiles + "%ProgramFiles%\\Microsoft SDKs\\Windows\\v7.1\\";
-            }
-
-            // current_cpu: x64, target_cpu: x64
-            vcTools = vcTools + "\\amd64;" + vcTools + "\\VCPackages;";
-            String sdkTools = windowsSdkDir + "Bin\\NETFX 4.0 Tools\\x64;"
-                    + windowsSdkDir + "Bin\\x64;"
-                    + windowsSdkDir + "Bin;";
-            String fxTools = frameworkDir64 + "\\" + frameworkVersion + ";"
-                    + frameworkDir32 + frameworkVersion + ";"
-                    + winDir + "\\Microsoft.NET\\Framework64\\v3.5;"
-                    + winDir + "\\Microsoft.NET\\Framework\\v3.5;";
-
-            String vsTools = vsInstallDir + "Common7\\IDE;" + vsInstallDir + "Common7\\Tools;";
-
-            String envPath = fxTools + ";" + vsTools + ";" + vcTools + ";" + sdkTools + ";" + path;
-            getLogger().debug("[env] PATH: {}", envPath);
-            spec.environment("PATH", envPath);
-
-            String vcLibraries = vcInstallDir + "Lib";
-            String vcIncludes = vcInstallDir + "INCLUDE";
-            String osLibraries = windowsSdkDir + "Lib";
-            String osIncludes = windowsSdkDir + "INCLUDE;" + windowsSdkDir + "INCLUDE\\gl";
-
-            String envLib = vcLibraries + "\\amd64;" + osLibraries + "\\X64";
-            String envLibPath = fxTools + ";" + vcLibraries + "\\amd64";
-            String envInclude = vcIncludes + ";" + osIncludes;
-
-            if (new File(vcInstallDir, "ATLMFC").exists()) {
-                envInclude += ";" + vcInstallDir + "ATLMFC\\INCLUDE";
-                envLib += ";" + vcInstallDir + "ATLMFC\\LIB";
-            }
-
-            getLogger().debug("[env] LIB: {}", envLib);
-            spec.environment("LIB", envLib);
-
-            getLogger().debug("[env] LIBPATH: {}", envLibPath);
-            spec.environment("LIBPATH", envLibPath);
-
-            getLogger().debug("[env] INCLUDE: {}", envInclude);
-            spec.environment("INCLUDE", envInclude);
-
-            String envAppVer = "6.1";
-            getLogger().debug("[env] APPVER: {}", envAppVer);
-            spec.environment("APPVER", envAppVer);
+            List<String> cmdArgs = new ArrayList<>();
+            // command extensions
+            cmdArgs.add("/E:ON");
+            // delayed environment variable expansion via !
+            cmdArgs.add("/V:ON");
+            cmdArgs.add("/c");
+            cmdArgs.add("\"" + startCmd.toString() + "\"");
+            spec.setExecutable("cmd.exe");
+            spec.setArgs(cmdArgs);
         }
     }
 
@@ -238,63 +169,6 @@ public abstract class BaseGraalCompileTask extends DefaultTask {
      Note that this fails, if the name contains "REG_", but it's ok here, since such keys aren't queried.
      */
     private static final Pattern regValueLine = Pattern.compile("^.+?REG_\\S+\\s+(.*)$");
-
-    private String readWindowsRegistryString(String key, String name) {
-        // launch: reg query <key> /v <name>
-        ProcessBuilder procBuilder = new ProcessBuilder(
-                "C:\\Windows\\System32\\reg.exe", "query", key, "/v", name);
-        Process proc;
-        try {
-            proc = procBuilder.start();
-        } catch (IOException e) {
-            throw new RuntimeException("Error querying windows registry: couldn't launch reg.exe", e);
-        }
-
-        /* example output:
-        cmd> reg query HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\SxS\VC7 /v FrameworkDir64
-
-        HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\SxS\VC7
-            FrameworkDir64    REG_SZ    C:\WINDOWS\Microsoft.NET\Framework64
-
-         */
-        BufferedReader reader = new BufferedReader(new InputStreamReader(proc.getInputStream()));
-
-        // find the first line that contains some non-whitespace and starts with whitespace
-        Optional<String> firstValueLine = reader.lines()
-                .filter(line -> line.trim().length() > 0 && line.matches("^\\s+.+$"))
-                .findFirst();
-
-        // wait for the process to finish
-        try {
-            proc.waitFor();
-        } catch (InterruptedException e) {
-            throw new RuntimeException("Error querying windows registry: thread was interrupted.", e);
-        }
-
-        try {
-            reader.close();
-        } catch (IOException e) {
-            throw new RuntimeException("Error querying windows registry: stream couldn't be closed.", e);
-        }
-
-        int exitValue = proc.exitValue();
-        if (exitValue == 1 || !firstValueLine.isPresent()) {
-            // key or name was not found
-            getLogger().debug("[registry] {} -> {} = not found (exit code: {})", key, name, exitValue);
-            return null;
-        }
-
-        String line = firstValueLine.get();
-        Matcher matcher = regValueLine.matcher(line);
-        if (!matcher.find()) {
-            getLogger().error("[registry] unexpected line format:\n{}", line);
-            throw new RuntimeException("Error querying windows registry: unexpected line format.");
-        }
-
-        String value = matcher.group(1);
-        getLogger().debug("[registry] {} -> {} = {}", key, name, value);
-        return value;
-    }
 
     protected static long fileSizeMegabytes(RegularFile regularFile) {
         try {

--- a/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
@@ -49,7 +49,7 @@ public class DownloadGraalTask extends DefaultTask {
         setGroup(GradleGraalPlugin.TASK_GROUP);
         setDescription("Downloads and caches GraalVM binaries.");
 
-        onlyIf(task -> !getTgz().get().getAsFile().exists());
+        onlyIf(task -> !getArchive().get().getAsFile().exists());
     }
 
     @TaskAction
@@ -61,12 +61,12 @@ public class DownloadGraalTask extends DefaultTask {
                 ? ARTIFACT_PATTERN_RC_VERSION : ARTIFACT_PATTERN_RELEASE_VERSION;
 
         try (InputStream in = new URL(render(artifactPattern)).openStream()) {
-            Files.copy(in, getTgz().get().getAsFile().toPath(), StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(in, getArchive().get().getAsFile().toPath(), StandardCopyOption.REPLACE_EXISTING);
         }
     }
 
     @OutputFile
-    public final Provider<RegularFile> getTgz() {
+    public final Provider<RegularFile> getArchive() {
         return getProject().getLayout()
                 .file(getCacheSubdirectory().map(dir -> dir.resolve(render(FILENAME_PATTERN)).toFile()));
     }

--- a/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
@@ -33,12 +33,13 @@ import org.gradle.api.tasks.TaskAction;
 /** Downloads GraalVM binaries. */
 public class DownloadGraalTask extends DefaultTask {
 
+    // RC versions don't have a windows variant, so no [ext] is needed
     private static final String ARTIFACT_PATTERN_RC_VERSION
             = "[url]/vm-[version]/graalvm-ce-[version]-[os]-[arch].tar.gz";
     private static final String ARTIFACT_PATTERN_RELEASE_VERSION
-            = "[url]/vm-[version]/graalvm-ce-[os]-[arch]-[version].tar.gz";
+            = "[url]/vm-[version]/graalvm-ce-[os]-[arch]-[version].[ext]";
 
-    private static final String FILENAME_PATTERN = "graalvm-ce-[version]-[arch].tar.gz";
+    private static final String FILENAME_PATTERN = "graalvm-ce-[version]-[arch].[ext]";
 
     private final Property<String> graalVersion = getProject().getObjects().property(String.class);
     private final Property<String> downloadBaseUrl = getProject().getObjects().property(String.class);
@@ -97,7 +98,8 @@ public class DownloadGraalTask extends DefaultTask {
                 .replaceAll("\\[url\\]", downloadBaseUrl.get())
                 .replaceAll("\\[version\\]", graalVersion.get())
                 .replaceAll("\\[os\\]", getOperatingSystem())
-                .replaceAll("\\[arch\\]", getArchitecture());
+                .replaceAll("\\[arch\\]", getArchitecture())
+                .replaceAll("\\[ext\\]", getArchiveExtension());
     }
 
     private String getOperatingSystem() {
@@ -106,6 +108,8 @@ public class DownloadGraalTask extends DefaultTask {
                 return isGraalRcVersion() ? "macos" : "darwin";
             case LINUX:
                 return "linux";
+            case WINDOWS:
+                return "windows";
             default:
                 throw new IllegalStateException("No GraalVM support for " + Platform.operatingSystem());
         }
@@ -117,6 +121,18 @@ public class DownloadGraalTask extends DefaultTask {
                 return "amd64";
             default:
                 throw new IllegalStateException("No GraalVM support for " + Platform.architecture());
+        }
+    }
+
+    private String getArchiveExtension() {
+        switch (Platform.operatingSystem()) {
+            case MAC:
+            case LINUX:
+                return "tar.gz";
+            case WINDOWS:
+                return "zip";
+            default:
+                throw new IllegalStateException("No GraalVM support for " + Platform.operatingSystem());
         }
     }
 

--- a/src/main/java/com/palantir/gradle/graal/ExtractGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/ExtractGraalTask.java
@@ -77,17 +77,32 @@ public class ExtractGraalTask extends DefaultTask {
         }
     }
 
+    // has some overlap with BaseGraalCompileTask#getArchitectureSpecifiedBinaryPath()
     private File getExecutable(String binaryName) {
+        String binaryExtension = "";
+
+        if (Platform.operatingSystem() == Platform.OperatingSystem.WINDOWS) {
+            // most executables in the GraalVM distribution for Windows have an .exe extension
+            if (binaryName.equals("native-image") || binaryName.equals("native-image-configure")
+                    || binaryName.equals("polyglot")) {
+                binaryExtension = ".cmd";
+            } else {
+                binaryExtension = ".exe";
+            }
+        }
+
         return cacheDir.get()
                 .resolve(Paths.get(graalVersion.get(), "graalvm-ce-" + graalVersion.get()))
-                .resolve(getArchitectureSpecifiedBinaryPath(binaryName))
+                .resolve(getArchitectureSpecifiedBinaryPath(binaryName + binaryExtension))
                 .toFile();
     }
 
     private Path getArchitectureSpecifiedBinaryPath(String binaryName) {
         switch (Platform.operatingSystem()) {
             case MAC: return Paths.get("Contents", "Home", "bin", binaryName);
-            case LINUX: return Paths.get("bin", binaryName);
+            case LINUX:
+            case WINDOWS:
+                return Paths.get("bin", binaryName);
             default:
                 throw new IllegalStateException("No GraalVM support for " + Platform.operatingSystem());
         }

--- a/src/main/java/com/palantir/gradle/graal/ExtractGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/ExtractGraalTask.java
@@ -20,6 +20,9 @@ import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.file.Directory;
@@ -35,6 +38,11 @@ import org.gradle.api.tasks.TaskAction;
 
 /** Extracts GraalVM tooling from downloaded tgz archive using the system's tar command. */
 public class ExtractGraalTask extends DefaultTask {
+    /**
+     * These binaries get .cmd as their filename extension, instead of .cmd (on Windows).
+     */
+    private static final Set<String> WINDOWS_CMD_BINARIES =
+            new HashSet<>(Arrays.asList("native-image", "native-image-configure", "polyglot"));
 
     private final RegularFileProperty inputArchive = getProject().getObjects().fileProperty();
     private final Property<String> graalVersion = getProject().getObjects().property(String.class);
@@ -97,8 +105,7 @@ public class ExtractGraalTask extends DefaultTask {
 
         if (Platform.operatingSystem() == Platform.OperatingSystem.WINDOWS) {
             // most executables in the GraalVM distribution for Windows have an .exe extension
-            if (binaryName.equals("native-image") || binaryName.equals("native-image-configure")
-                    || binaryName.equals("polyglot")) {
+            if (WINDOWS_CMD_BINARIES.contains(binaryName)) {
                 binaryExtension = ".cmd";
             } else {
                 binaryExtension = ".exe";

--- a/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
+++ b/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
@@ -71,7 +71,7 @@ public class GradleGraalPlugin implements Plugin<Project> {
                 ExtractGraalTask.class,
                 task -> {
                     task.setGraalVersion(extension.getGraalVersion());
-                    task.setInputTgz(downloadGraal.get().getTgz());
+                    task.setInputArchive(downloadGraal.get().getArchive());
                     task.setCacheDir(cacheDir);
                     task.dependsOn(downloadGraal);
                 });

--- a/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
+++ b/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
@@ -83,7 +83,7 @@ public class NativeImageTask extends BaseGraalCompileTask {
     private class LogAction implements Action<Task> {
         @Override
         public void execute(Task task) {
-            getLogger().warn("native image available at {} ({}MB)",
+            getLogger().warn("native image available at {} ({} MB)",
                     getProject().relativePath(getOutputFile().get().getAsFile()),
                     fileSizeMegabytes(getOutputFile().get()));
         }

--- a/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
+++ b/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
@@ -17,12 +17,10 @@
 package com.palantir.gradle.graal;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
-import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
@@ -37,8 +35,28 @@ public class NativeImageTask extends BaseGraalCompileTask {
 
     public NativeImageTask() {
         setDescription("Runs GraalVM's native-image command with configured options and parameters.");
+
         // must use an anonymous inner class instead of a lambda to get Gradle staleness checking
         doLast(new LogAction());
+    }
+
+    /**
+     * Returns a platform-dependent file extension for executables.
+     *
+     * @return an empty String on {@link Platform.OperatingSystem#MAC MAC} and
+     *         {@link Platform.OperatingSystem#LINUX LINUX}, ".exe" on {@link Platform.OperatingSystem#WINDOWS WINDOWS}
+     */
+    @Override
+    protected String getArchitectureSpecifiedOutputExtension() {
+        switch (Platform.operatingSystem()) {
+            case MAC:
+            case LINUX:
+                return "";
+            case WINDOWS:
+                return ".exe";
+            default:
+                throw new IllegalStateException("No GraalVM support for " + Platform.operatingSystem());
+        }
     }
 
     @TaskAction
@@ -47,6 +65,7 @@ public class NativeImageTask extends BaseGraalCompileTask {
         configureArgs(args);
         args.add(mainClass.get());
         getProject().exec(spec -> {
+            configurePlatformSpecifics(spec);
             spec.executable(getExecutable());
             spec.args(args);
         });
@@ -61,18 +80,10 @@ public class NativeImageTask extends BaseGraalCompileTask {
         mainClass.set(provider);
     }
 
-    private long fileSizeMegabytes(RegularFile regularFile) {
-        try {
-            return Files.size(regularFile.getAsFile().toPath()) / (1000 * 1000);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     private class LogAction implements Action<Task> {
         @Override
         public void execute(Task task) {
-            getLogger().warn("native-image available at {} ({}MB)",
+            getLogger().warn("native image available at {} ({}MB)",
                     getProject().relativePath(getOutputFile().get().getAsFile()),
                     fileSizeMegabytes(getOutputFile().get()));
         }

--- a/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
+++ b/src/main/java/com/palantir/gradle/graal/NativeImageTask.java
@@ -65,9 +65,9 @@ public class NativeImageTask extends BaseGraalCompileTask {
         configureArgs(args);
         args.add(mainClass.get());
         getProject().exec(spec -> {
+            spec.setExecutable(getExecutable());
+            spec.setArgs(args);
             configurePlatformSpecifics(spec);
-            spec.executable(getExecutable());
-            spec.args(args);
         });
     }
 

--- a/src/main/java/com/palantir/gradle/graal/SharedLibraryTask.java
+++ b/src/main/java/com/palantir/gradle/graal/SharedLibraryTask.java
@@ -62,9 +62,9 @@ public class SharedLibraryTask extends BaseGraalCompileTask {
         args.add("--shared");
         configureArgs(args);
         getProject().exec(spec -> {
+            spec.setExecutable(getExecutable());
+            spec.setArgs(args);
             configurePlatformSpecifics(spec);
-            spec.executable(getExecutable());
-            spec.args(args);
         });
     }
 

--- a/src/main/java/com/palantir/gradle/graal/SharedLibraryTask.java
+++ b/src/main/java/com/palantir/gradle/graal/SharedLibraryTask.java
@@ -71,7 +71,7 @@ public class SharedLibraryTask extends BaseGraalCompileTask {
     private class LogAction implements Action<Task> {
         @Override
         public void execute(Task task) {
-            getLogger().warn("shared library available at {} ({}MB)",
+            getLogger().warn("shared library available at {} ({} MB)",
                     getProject().relativePath(getOutputFile().get().getAsFile()),
                     fileSizeMegabytes(getOutputFile().get()));
         }

--- a/src/main/java/com/palantir/gradle/graal/SharedLibraryTask.java
+++ b/src/main/java/com/palantir/gradle/graal/SharedLibraryTask.java
@@ -19,6 +19,8 @@ package com.palantir.gradle.graal;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import org.gradle.api.Action;
+import org.gradle.api.Task;
 import org.gradle.api.tasks.TaskAction;
 
 /**
@@ -30,6 +32,28 @@ public class SharedLibraryTask extends BaseGraalCompileTask {
         setDescription(
                 "Runs GraalVM's native-image command configured to produce a shared library."
         );
+        // must use an anonymous inner class instead of a lambda to get Gradle staleness checking
+        doLast(new LogAction());
+    }
+
+    /**
+     * Returns a platform-dependent file extension for libraries.
+     *
+     * @return ".dylib" on {@link Platform.OperatingSystem#MAC MAC}, ".so" on
+     *          {@link Platform.OperatingSystem#LINUX LINUX}, ".dll" on {@link Platform.OperatingSystem#WINDOWS WINDOWS}
+     */
+    @Override
+    protected String getArchitectureSpecifiedOutputExtension() {
+        switch (Platform.operatingSystem()) {
+            case MAC:
+                return ".dylib";
+            case LINUX:
+                return ".so";
+            case WINDOWS:
+                return ".dll";
+            default:
+                throw new IllegalStateException("No GraalVM support for " + Platform.operatingSystem());
+        }
     }
 
     @TaskAction
@@ -38,9 +62,19 @@ public class SharedLibraryTask extends BaseGraalCompileTask {
         args.add("--shared");
         configureArgs(args);
         getProject().exec(spec -> {
+            configurePlatformSpecifics(spec);
             spec.executable(getExecutable());
             spec.args(args);
         });
+    }
+
+    private class LogAction implements Action<Task> {
+        @Override
+        public void execute(Task task) {
+            getLogger().warn("shared library available at {} ({}MB)",
+                    getProject().relativePath(getOutputFile().get().getAsFile()),
+                    fileSizeMegabytes(getOutputFile().get()));
+        }
     }
 
 }

--- a/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
@@ -20,6 +20,7 @@ import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
 import static com.palantir.gradle.graal.Platform.OperatingSystem.LINUX
 import static com.palantir.gradle.graal.Platform.OperatingSystem.MAC
+import static com.palantir.gradle.graal.Platform.OperatingSystem.WINDOWS
 
 class GradleGraalEndToEndSpec extends IntegrationSpec {
 
@@ -49,11 +50,15 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         ExecutionResult result = runTasksSuccessfully('nativeImage') // note, this accesses your real ~/.gradle cache
         println "Gradle Standard Out:\n" + result.standardOutput
         println "Gradle Standard Error:\n" + result.standardError
-        File output = new File(getProjectDir(), "build/graal/hello-world");
+        def outputPath = "build/graal/hello-world"
+        if (Platform.operatingSystem() == Platform.OperatingSystem.WINDOWS) {
+            outputPath += ".exe"
+        }
+        File output = new File(getProjectDir(), outputPath);
 
         then:
         output.exists()
-        output.getAbsolutePath().execute().text.equals("hello, world!\n")
+        output.getAbsolutePath().execute().text.equals("hello, world!" + System.lineSeparator())
 
         when:
         ExecutionResult result2 = runTasksSuccessfully('nativeImage')
@@ -98,7 +103,7 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         graal {
             mainClass 'com.palantir.test.Main'
             outputName 'hello-world'
-            graalVersion '1.0.0-rc5'
+            graalVersion '19.1.0'
         }
         '''
 
@@ -106,11 +111,15 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         ExecutionResult result = runTasksSuccessfully('nativeImage') // note, this accesses your real ~/.gradle cache
         println "Gradle Standard Out:\n" + result.standardOutput
         println "Gradle Standard Error:\n" + result.standardError
-        File output = new File(getProjectDir(), "build/graal/hello-world");
+        def outputPath = "build/graal/hello-world"
+        if (Platform.operatingSystem() == Platform.OperatingSystem.WINDOWS) {
+            outputPath += ".exe"
+        }
+        File output = new File(getProjectDir(), outputPath);
 
         then:
         output.exists()
-        output.getAbsolutePath().execute().text.equals("hello, world!\n")
+        output.getAbsolutePath().execute().text.equals("hello, world!" + System.lineSeparator())
 
         when:
         ExecutionResult result2 = runTasksSuccessfully('nativeImage')
@@ -133,7 +142,7 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         then:
         println result3.standardOutput
         !result3.wasUpToDate(':nativeImage')
-        output.getAbsolutePath().execute().text.equals("hello, world (modified)!\n")
+        output.getAbsolutePath().execute().text.equals("hello, world (modified)!" + System.lineSeparator())
     }
 
     def 'allows specifying additional properties'() {
@@ -164,7 +173,7 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         graal {
             mainClass 'com.palantir.test.Main'
             outputName 'hello-world'
-            graalVersion '1.0.0-rc5'
+            graalVersion '19.1.0'
             // By default, only file:// is supported, see https://github.com/oracle/graal/blob/master/substratevm/URL-PROTOCOLS.md
             option '-H:EnableURLProtocols=http'
         }
@@ -174,7 +183,11 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         ExecutionResult result = runTasks('nativeImage') // note, this accesses your real ~/.gradle cache
         println "Gradle Standard Out:\n" + result.standardOutput
         println "Gradle Standard Error:\n" + result.standardError
-        File output = new File(getProjectDir(), "build/graal/hello-world");
+        def outputPath = "build/graal/hello-world"
+        if (Platform.operatingSystem() == Platform.OperatingSystem.WINDOWS) {
+            outputPath += ".exe"
+        }
+        File output = new File(getProjectDir(), outputPath);
 
         then:
         output.exists()
@@ -214,7 +227,7 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         apply plugin: 'com.palantir.graal'
         graal {
             outputName 'hello-world'
-            graalVersion '1.0.0-rc5'
+            graalVersion '19.1.0'
         }
         '''
 
@@ -232,6 +245,8 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
                 return "dylib"
             case LINUX:
                 return "so"
+            case WINDOWS:
+                return "dll"
             default:
                 throw new IllegalStateException("No GraalVM support for " + Platform.operatingSystem())
         }
@@ -243,7 +258,7 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
 
         graal {            
             outputName 'hello-world'
-            graalVersion '1.0.0-rc5'
+            graalVersion '19.1.0'
             option '-H:EnableURLProtocols=http'            
         }
         '''
@@ -264,7 +279,7 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         graal {
             mainClass 'com.palantir.test.Main'
             outputName 'hello-world'
-            graalVersion '1.0.0-rc5'
+            graalVersion '19.1.0'
             option '-H:EnableURLProtocols=http'
             option '-H:Name=foo'
         }

--- a/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
@@ -18,6 +18,8 @@ package com.palantir.gradle.graal
 
 import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
+import spock.lang.IgnoreIf
+
 import static com.palantir.gradle.graal.Platform.OperatingSystem.LINUX
 import static com.palantir.gradle.graal.Platform.OperatingSystem.MAC
 import static com.palantir.gradle.graal.Platform.OperatingSystem.WINDOWS
@@ -51,10 +53,10 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         println "Gradle Standard Out:\n" + result.standardOutput
         println "Gradle Standard Error:\n" + result.standardError
         def outputPath = "build/graal/hello-world"
-        if (Platform.operatingSystem() == Platform.OperatingSystem.WINDOWS) {
+        if (Platform.operatingSystem() == WINDOWS) {
             outputPath += ".exe"
         }
-        File output = new File(getProjectDir(), outputPath);
+        File output = new File(getProjectDir(), outputPath)
 
         then:
         output.exists()
@@ -81,9 +83,11 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         then:
         println result3.standardOutput
         !result3.wasUpToDate(':nativeImage')
-        output.getAbsolutePath().execute().text.equals("hello, world (modified)!\n")
+        output.getAbsolutePath().execute().text.equals("hello, world (modified)!" + System.lineSeparator())
     }
 
+    // there is no RC version for Windows
+    @IgnoreIf({ Platform.operatingSystem() == WINDOWS })
     def 'test 1.0.0-rc5 nativeImage'() {
         setup:
         directory("src/main/java/com/palantir/test")
@@ -103,7 +107,7 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         graal {
             mainClass 'com.palantir.test.Main'
             outputName 'hello-world'
-            graalVersion '19.1.0'
+            graalVersion '1.0.0-rc5'
         }
         '''
 
@@ -115,7 +119,7 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         if (Platform.operatingSystem() == Platform.OperatingSystem.WINDOWS) {
             outputPath += ".exe"
         }
-        File output = new File(getProjectDir(), outputPath);
+        File output = new File(getProjectDir(), outputPath)
 
         then:
         output.exists()
@@ -184,10 +188,10 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         println "Gradle Standard Out:\n" + result.standardOutput
         println "Gradle Standard Error:\n" + result.standardError
         def outputPath = "build/graal/hello-world"
-        if (Platform.operatingSystem() == Platform.OperatingSystem.WINDOWS) {
+        if (Platform.operatingSystem() == WINDOWS) {
             outputPath += ".exe"
         }
-        File output = new File(getProjectDir(), outputPath);
+        File output = new File(getProjectDir(), outputPath)
 
         then:
         output.exists()
@@ -216,6 +220,8 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         dylibFile.exists()
     }
 
+    // there is no RC version for Windows
+    @IgnoreIf({ Platform.operatingSystem() == WINDOWS })
     def 'can build shared libraries on 1.0.0-rc5'() {
         setup:
         directory("src/main/java/com/palantir/test")
@@ -227,7 +233,7 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         apply plugin: 'com.palantir.graal'
         graal {
             outputName 'hello-world'
-            graalVersion '19.1.0'
+            graalVersion '1.0.0-rc5'
         }
         '''
 

--- a/src/test/groovy/com/palantir/gradle/graal/GradleGraalPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleGraalPluginIntegrationSpec.groovy
@@ -21,6 +21,8 @@ import nebula.test.functional.ExecutionResult
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Rule
+import spock.lang.IgnoreIf
+import spock.lang.Requires
 
 class GradleGraalPluginIntegrationSpec extends IntegrationSpec {
 
@@ -41,9 +43,13 @@ class GradleGraalPluginIntegrationSpec extends IntegrationSpec {
             }
         '''
 
-        file('gradle.properties') << "com.palantir.graal.cache.dir=${getProjectDir().toPath().resolve("cacheDir").toAbsolutePath()}"
+        // on Windows the path contains backslashes, which need to be escaped in .properties files
+        def cacheDirPath = getProjectDir().toPath().resolve("cacheDir").toAbsolutePath().toString().replace("\\", "\\\\")
+        file('gradle.properties') << "com.palantir.graal.cache.dir=${cacheDirPath}"
     }
 
+    // there is no RC version for Windows
+    @IgnoreIf({ Platform.operatingSystem() == Platform.OperatingSystem.WINDOWS })
     def 'allows specifying different RC graal version'() {
         setup:
         buildFile << """
@@ -65,13 +71,16 @@ class GradleGraalPluginIntegrationSpec extends IntegrationSpec {
         !result.wasUpToDate(':downloadGraalTooling')
         !result.wasSkipped(':downloadGraalTooling')
 
-        server.takeRequest().requestUrl.toString() =~ "http://localhost:${server.port}" +
+        // requestUrl can contain "127.0.0.1" instead of "localhost"
+        server.takeRequest().requestUrl.toString() =~ "http://(localhost|127\\.0\\.0\\.1):${server.port}" +
                 "/oracle/graal/releases/download//vm-1.0.0-rc3/graalvm-ce-1.0.0-rc3-(macos|linux)-amd64.tar.gz"
 
         file("cacheDir/1.0.0-rc3/graalvm-ce-1.0.0-rc3-amd64.tar.gz").text == '<<tgz>>'
     }
 
-    def 'allows specifying different GA graal version'() {
+    // for Windows the download is a .zip, this is tested below
+    @IgnoreIf({ Platform.operatingSystem() == Platform.OperatingSystem.WINDOWS })
+    def 'allows specifying different GA graal version (non-windows)'() {
         setup:
         buildFile << """
             apply plugin: 'com.palantir.graal'
@@ -92,10 +101,39 @@ class GradleGraalPluginIntegrationSpec extends IntegrationSpec {
         !result.wasUpToDate(':downloadGraalTooling')
         !result.wasSkipped(':downloadGraalTooling')
 
-        server.takeRequest().requestUrl.toString() =~ "http://localhost:${server.port}" +
+        // requestUrl can contain "127.0.0.1" instead of "localhost"
+        server.takeRequest().requestUrl.toString() =~ "http://(localhost|127\\.0\\.0\\.1):${server.port}" +
                 "/oracle/graal/releases/download//vm-19.0.0/graalvm-ce-(darwin|linux)-amd64-19.0.0.tar.gz"
 
         file("cacheDir/19.0.0/graalvm-ce-19.0.0-amd64.tar.gz").text == '<<tgz>>'
+    }
+
+    @Requires({ Platform.operatingSystem() == Platform.OperatingSystem.WINDOWS })
+    def 'allows specifying different GA graal version (windows)'() {
+        setup:
+        buildFile << """
+            apply plugin: 'com.palantir.graal'
+
+            graal {
+               graalVersion '19.0.0'
+               downloadBaseUrl '${fakeBaseUrl}'
+            }
+        """
+        server.enqueue(new MockResponse().setBody('<<zip>>'));
+
+        when:
+        ExecutionResult result = runTasksSuccessfully('downloadGraalTooling')
+
+        then:
+        println result.getStandardOutput()
+        result.wasExecuted(':downloadGraalTooling')
+        !result.wasUpToDate(':downloadGraalTooling')
+        !result.wasSkipped(':downloadGraalTooling')
+        // requestUrl can contain "127.0.0.1" instead of "localhost"
+        server.takeRequest().requestUrl.toString() =~ "http://(localhost|127\\.0\\.0\\.1):${server.port}" +
+          "/oracle/graal/releases/download//vm-19.0.0/graalvm-ce-windows-amd64-19.0.0.zip"
+
+        file("cacheDir/19.0.0/graalvm-ce-19.0.0-amd64.zip").text == '<<zip>>'
     }
 
     def 'downloadGraalTooling behaves incrementally'() {

--- a/src/test/groovy/com/palantir/gradle/graal/GradleGraalPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleGraalPluginIntegrationSpec.groovy
@@ -60,7 +60,7 @@ class GradleGraalPluginIntegrationSpec extends IntegrationSpec {
                downloadBaseUrl '${fakeBaseUrl}'
             }
         """
-        server.enqueue(new MockResponse().setBody('<<tgz>>'));
+        server.enqueue(new MockResponse().setBody('<<tgz>>'))
 
         when:
         ExecutionResult result = runTasksSuccessfully('downloadGraalTooling')
@@ -90,7 +90,7 @@ class GradleGraalPluginIntegrationSpec extends IntegrationSpec {
                downloadBaseUrl '${fakeBaseUrl}'
             }
         """
-        server.enqueue(new MockResponse().setBody('<<tgz>>'));
+        server.enqueue(new MockResponse().setBody('<<tgz>>'))
 
         when:
         ExecutionResult result = runTasksSuccessfully('downloadGraalTooling')
@@ -101,9 +101,12 @@ class GradleGraalPluginIntegrationSpec extends IntegrationSpec {
         !result.wasUpToDate(':downloadGraalTooling')
         !result.wasSkipped(':downloadGraalTooling')
 
-        // requestUrl can contain "127.0.0.1" instead of "localhost"
-        server.takeRequest().requestUrl.toString() =~ "http://(localhost|127\\.0\\.0\\.1):${server.port}" +
-                "/oracle/graal/releases/download//vm-19.0.0/graalvm-ce-(darwin|linux)-amd64-19.0.0.tar.gz"
+        // `requestUrl` can contain "127.0.0.1" instead of "localhost"
+        // worse yet, it can contain any hostname that is defined for 127.0.0.1 in the hosts file
+        // e.g. Docker Desktop puts "127.0.0.1 kubernetes.docker.internal" in there, which ends up in `requestUrl`
+        // so the comparison is only made for `path`
+        server.takeRequest().path =~
+          "/oracle/graal/releases/download//vm-19.0.0/graalvm-ce-(darwin|linux)-amd64-19.0.0.tar.gz"
 
         file("cacheDir/19.0.0/graalvm-ce-19.0.0-amd64.tar.gz").text == '<<tgz>>'
     }
@@ -119,7 +122,7 @@ class GradleGraalPluginIntegrationSpec extends IntegrationSpec {
                downloadBaseUrl '${fakeBaseUrl}'
             }
         """
-        server.enqueue(new MockResponse().setBody('<<zip>>'));
+        server.enqueue(new MockResponse().setBody('<<zip>>'))
 
         when:
         ExecutionResult result = runTasksSuccessfully('downloadGraalTooling')
@@ -129,8 +132,12 @@ class GradleGraalPluginIntegrationSpec extends IntegrationSpec {
         result.wasExecuted(':downloadGraalTooling')
         !result.wasUpToDate(':downloadGraalTooling')
         !result.wasSkipped(':downloadGraalTooling')
-        // requestUrl can contain "127.0.0.1" instead of "localhost"
-        server.takeRequest().requestUrl.toString() =~ "http://(localhost|127\\.0\\.0\\.1):${server.port}" +
+
+        // `requestUrl` can contain "127.0.0.1" instead of "localhost"
+        // worse yet, it can contain any hostname that is defined for 127.0.0.1 in the hosts file
+        // e.g. Docker Desktop puts "127.0.0.1 kubernetes.docker.internal" in there, which ends up in `requestUrl`
+        // so the comparison is only made for `path`
+        server.takeRequest().path =~
           "/oracle/graal/releases/download//vm-19.0.0/graalvm-ce-windows-amd64-19.0.0.zip"
 
         file("cacheDir/19.0.0/graalvm-ce-19.0.0-amd64.zip").text == '<<zip>>'
@@ -145,7 +152,7 @@ class GradleGraalPluginIntegrationSpec extends IntegrationSpec {
                downloadBaseUrl '${fakeBaseUrl}'
             }
         """
-        server.enqueue(new MockResponse().setBody('<<tgz>>'));
+        server.enqueue(new MockResponse().setBody('<<tgz>>'))
 
         when:
         ExecutionResult result1 = runTasksSuccessfully('downloadGraalTooling')


### PR DESCRIPTION
Hi there,

This PR adds Windows support to the only Gradle GraalVM plugin (this one!) - a much needed feature, I imagine (using Windows myself and experimenting with GraalVM). With this PR `gradle-graal` supports building native images and shared libraries on Windows, if you install the prerequisites GraalVM needs.

I haven't opened an issue, because discussing this code directly instead of theoretically seems better.

## How to test

Install the required dependencies for GraalVM to work on windows (see [substratevm/README.md](https://github.com/oracle/graal/blob/master/substratevm/README.md#quick-start)) and make sure GraalVM can successfully compile something standalone (remember to use the *Windows SDK Command Prompt* when running `native-image` directly).

- Clone [my `windows` branch](https://github.com/frozenice/gradle-graal/tree/windows)
- Run the Gradle task `publishToMavenLocal`
- Run the Gradle task `printVersion`, this will print something like `0.3.0-38-g2b56d74`
- In your project, add `mavenLocal()` and the locally published plugin to the buildscript dependencies, e.g.:
  ```gradle
  buildscript {
    repositories {
      mavenLocal()
      mavenCentral()
    }

    dependencies {
      classpath 'com.palantir.graal:gradle-graal:0.3.0-38-g2b56d74'
    }
  }
  ```
  (must be the first block in your build.gradle)
- Make sure you don't include `gradle-graal` via a `plugins` block or otherwise
- Configure the `graal` extension, e.g.:
  ```gradle
  graal {
    graalVersion "19.1.0"
    mainClass mainClassName
    outputName "graal-test"
  }
  ```
  (replace `mainClassName` with a string containing your entry class name if you haven't applied the `application` plugin)
- Run the Gradle task `nativeImage`, it will print the output location (the `sharedLibrary` task also works)

## Changes

### DownloadGraalTask

Enabling the download of the windows archive required adding a `WINDOWS` case to `getOperatingSystem` and a new `getArchiveExtension` method (it's `.zip` on Windows).

There is a new `[ext]` placeholder, which is used in `ARTIFACT_PATTERN_RELEASE_VERSION` (RC versions don't have a Windows variant) and `FILENAME_PATTERN`. It's replaced in `render`.

### ExtractGraalTask

The recent [version 19 support](https://github.com/palantir/gradle-graal/commit/b5567e451629ee75779b8f9b8c537e926e8f3350) added `getExecutable` and `getArchitectureSpecifiedBinaryPath`. I added Windows support to those (a bit of complexity arose, because some executables in the GraalVM Windows distribution have .cmd as an extension, others have .exe).

### BaseGraalCompileTask

I added an abstract method `getArchitectureSpecifiedOutputExtension` so subclasses (`NativeImageTask` and `SharedLibraryTask`) can specify the platform-dependant file extension for their output.

There is also a new `getArchitectureSpecifiedPathSeparator` method, because path separators differ (`;` in Windows, `:` on Unix).

A `WINDOWS` case was added to `getArchitectureSpecifiedBinaryPath`, so it finds the `native-image` command.

To overcome the need for running inside the *Windows SDK Command Prompt* (`SetEnv.cmd`) I replicated the environment variables configuration, stripped to a minimum (it sets the following environment variables when launching `native-image`: `CL`, `PATH`, `LIB`, `LIBPATH`, `INCLUDE`, `APPVER`).

To do this, it needs to read some values from the Windows registry. This is done in `readWindowsRegistryString`, which is a very simple (but sufficient) wrapper around reg.exe to query a value from the registry.

`fileSizeMegabytes` was lifted from `NativeImageTask` so it can be used in all subclasses.

### NativeImageTask

The overriden method `getArchitectureSpecifiedOutputExtension` returns `.exe` on Windows and an empty string on Linux and Mac.

`configurePlatformSpecifics` is called in the `@TaskAction`.

### SharedLibraryTask

Basically the same as `NativeImageTask`, the extensions in `getArchitectureSpecifiedOutputExtension` are different, though.

Oh, and I also added the `LogAction`, like in `NativeImageTask`.

### Tests

I upgraded some GraalVM version that's used in tests to the current `19.1.0` (it must be 19+ so the tests can run on Windows).

Some cross-platform enhancements include:
- Specifying `.exe` and `dll` for the output file extensions on Windows (could use `getArchitectureSpecifiedOutputExtension` too)
- Replacing hardcoded `\n`s with `System.lineSeparator()`
- Escape backslashes in the generated `gradle.properties` file
- ~Allowing both `localhost` and `127.0.0.1` in `requestUrl` returned by the mock server~
- Just compare the path of mock server requests (because the hostname is not always 127.0.0.1or even localhost).

The tests *allows specifying different RC graal version*, *test 1.0.0-rc5 nativeImage* and *can build shared libraries on 1.0.0-rc5* are now ignored on Windows, because there is no GraalVM RC version for Windows. 

The test *allows specifying different GA graal version* was split into a version for Windows and another version for Linux / Mac. There are some things that are different on Windows. This looks a bit like duplicate code (which it is), but parameterizing all the places looked a bit much.

## Notes

There are some baseline warnings. `SwitchStatementDefaultCase` was already present, `DefaultCharset` is new, but I'm not sure what to do about it. Of course it needs to use the default platform charset to read the command output! Using `Charset.defaultCharset()` produced another warning.

I haven't run tests on Linux or Mac yet.

Cheers 🍺 
David