### PR TITLE
Add support for Windows native image

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ Configure this plugin and its wrappers around GraalVM tools through the `graal` 
 * `mainClass`: the main class entry-point for the image to run
 * `option`: additional native-image options `https://github.com/oracle/graal/blob/master/substratevm/OPTIONS.md`
 
+Preconditions when using on Windows
+-----------------------------------
+
+GraalVM [needs](https://github.com/oracle/graal/issues/1258) the [Microsoft Windows SDK for Windows 7 and .NET Framework 4](https://www.microsoft.com/en-us/download/details.aspx?id=8442) as well as [the C compilers from KB2519277](https://stackoverflow.com/a/45784634/873282).
+
+You can install it using [chocolatey](https://chocolatey.org/):
+
+    choco install windows-sdk-7.1 kb2519277
+
 Local GraalVM Tooling Cache
 ---------------------------
 We maintain a number of different repositories, and rather than re-download tooling and cache it per repository, this

--- a/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
+++ b/src/main/java/com/palantir/gradle/graal/GradleGraalPlugin.java
@@ -71,7 +71,7 @@ public class GradleGraalPlugin implements Plugin<Project> {
                 ExtractGraalTask.class,
                 task -> {
                     task.setGraalVersion(extension.getGraalVersion());
-                    task.setInputTgz(downloadGraal.get().getTgz());
+                    task.setInputFile(downloadGraal.get().getFile());
                     task.setCacheDir(cacheDir);
                     task.dependsOn(downloadGraal);
                 });

--- a/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleGraalEndToEndSpec.groovy
@@ -49,11 +49,11 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         ExecutionResult result = runTasksSuccessfully('nativeImage') // note, this accesses your real ~/.gradle cache
         println "Gradle Standard Out:\n" + result.standardOutput
         println "Gradle Standard Error:\n" + result.standardError
-        File output = new File(getProjectDir(), "build/graal/hello-world");
+        File output = new File(getProjectDir(), "build/graal/hello-world" + (Platform.operatingSystem().name().equals("WINDOWS") ? ".exe" : ""));
 
         then:
         output.exists()
-        output.getAbsolutePath().execute().text.equals("hello, world!\n")
+        output.getAbsolutePath().execute().text.startsWith("hello, world!")
 
         when:
         ExecutionResult result2 = runTasksSuccessfully('nativeImage')
@@ -76,7 +76,7 @@ class GradleGraalEndToEndSpec extends IntegrationSpec {
         then:
         println result3.standardOutput
         !result3.wasUpToDate(':nativeImage')
-        output.getAbsolutePath().execute().text.equals("hello, world (modified)!\n")
+        output.getAbsolutePath().execute().text.startsWith("hello, world (modified)!")
     }
 
     def 'test 1.0.0-rc5 nativeImage'() {

--- a/src/test/groovy/com/palantir/gradle/graal/GradleGraalPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleGraalPluginIntegrationSpec.groovy
@@ -41,7 +41,8 @@ class GradleGraalPluginIntegrationSpec extends IntegrationSpec {
             }
         '''
 
-        file('gradle.properties') << "com.palantir.graal.cache.dir=${getProjectDir().toPath().resolve("cacheDir").toAbsolutePath()}"
+        // for Windows, we need to replace \ by / as the netflix tooling cannot deal with real Windows paths
+        file('gradle.properties') << "com.palantir.graal.cache.dir=${getProjectDir().toPath().resolve("cacheDir").toAbsolutePath().toString().replaceAll("\\\\", "/")}"
     }
 
     def 'allows specifying different RC graal version'() {


### PR DESCRIPTION
GraalVM introduced Windows support in version 19.0.0: https://github.com/oracle/graal/releases/tag/vm-19.0.0

## Before this PR

Gradle output:

```
* What went wrong:

Execution failed for task ':downloadGraalTooling'.

> No GraalVM support for WINDOWS
```

## After this PR

Creates windows executables

## Possible downsides?

- `README.md` contains information for Windows
- Users have to install some tooling on Windows to get the thing running
- A temporary directory (containing a single file) is created for each run
- The code has some not too nice tweaks for windows (handling file extension `.exe` is one example)
- Only the test case `test default version nativeImage` runs on windows. The other ones depend on an older version of GraalVM
