### PR TITLE
filter non-jar objects from the classpath so svm sdk doesn't fail the…

### DIFF
--- a/src/main/java/com/palantir/gradle/graal/BaseGraalCompileTask.java
+++ b/src/main/java/com/palantir/gradle/graal/BaseGraalCompileTask.java
@@ -99,7 +99,12 @@ public abstract class BaseGraalCompileTask extends DefaultTask {
     protected final String generateClasspathArgument() {
         Set<File> classpathArgument = new LinkedHashSet<>();
 
-        classpathArgument.addAll(classpath.get().getFiles());
+        classpathArgument.addAll(classpath.get()
+                .getFiles()
+                .stream()
+                .filter(file -> file.getName()
+                        .endsWith(".jar"))
+                .collect(Collectors.toList()));
         classpathArgument.add(jarFile.getAsFile().get());
 
         return classpathArgument.stream()


### PR DESCRIPTION

## Before this PR
Could not use substrate SDK in any project because classpath contains a `.tar.gz` file, pulled in by the svm dependency itself.

## After this PR
filter non-jar objects from the classpath so svm sdk or other dependencies with non-ZIP files don't fail the build

## Possible downsides?
Dependencies that pull in non-zip files into the classpath may not work as expected. (Not sure if this is a valid use-case.)
