### PR TITLE
Don't publish snapshots to gradle plugin portal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,10 @@ pluginBundle {
     }
 }
 
+publishPlugins.onlyIf {
+    versionDetails().isCleanTag
+}
+
 tasks.withType(JavaCompile).configureEach {
     options.errorprone.errorproneArgs += [
             '-Xep:PreferSafeLoggableExceptions:OFF',


### PR DESCRIPTION
## Before this PR

@kdabir flagged that Gradle plugin portal is listing every version of this thing, likely causing lots of dependabot downstream PRs: https://github.com/palantir/gradle-graal/pull/371#issuecomment-701907692

Previous attempt to solve this did a few things in one PR and got stalebot'd: https://github.com/palantir/gradle-graal/pull/371

## After this PR
==COMMIT_MSG==
Snapshots are no longer published to gradle plugin portal
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

