### PR TITLE
Bump default graal version to 20.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Configuration
 Configure this plugin and its wrappers around GraalVM tools through the `graal` extension with the following options:
 
 **General GraalVM controls**
-* `graalVersion`: the version string to use when downloading GraalVM (defaults to `20.0.0`)
+* `graalVersion`: the version string to use when downloading GraalVM (defaults to `20.2.0`)
 * `downloadBaseUrl`: the base download URL to use (defaults to `https://github.com/oracle/graal/releases/download/`)
 * `javaVersion`: the Java version to use (can be either `8` or `11`, defaults to `8`)
     * for `8`: Windows SDK 7.1 will be used (`C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd`)

--- a/changelog/@unreleased/pr-396.v2.yml
+++ b/changelog/@unreleased/pr-396.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Bump default graal version to 20.2.0
+  links:
+    - https://github.com/palantir/gradle-graal/pull/396

--- a/src/main/java/com/palantir/gradle/graal/GraalExtension.java
+++ b/src/main/java/com/palantir/gradle/graal/GraalExtension.java
@@ -43,7 +43,7 @@ public class GraalExtension {
     private static final String DEFAULT_DOWNLOAD_BASE_URL = "https://github.com/oracle/graal/releases/download/";
     private static final String DOWNLOAD_BASE_URL_GRAAL_19_3 =
             "https://github.com/graalvm/graalvm-ce-builds/" + "releases/download/";
-    private static final String DEFAULT_GRAAL_VERSION = "20.0.0";
+    private static final String DEFAULT_GRAAL_VERSION = "20.2.0";
     private static final List<String> SUPPORTED_JAVA_VERSIONS = Arrays.asList("11", "8");
     private static final String DEFAULT_JAVA_VERSION = "8";
 


### PR DESCRIPTION
This pull request bumps the default graal version to 20.2.0. This should be the default because the current version fails if the project uses loops inside of coroutines. 

More details: https://github.com/oracle/graal/issues/366
