### PR TITLE
Support Java 16 for Graal 21.1.0

### DIFF
--- a/changelog/@unreleased/pr-432.v2.yml
+++ b/changelog/@unreleased/pr-432.v2.yml
@@ -1,5 +1,5 @@
 type: feature
-improvement:
+feature:
   description: Support Java 16 for GraalVM 21.1.0 and greater
   links:
     - https://github.com/palantir/gradle-graal/pull/432

--- a/changelog/@unreleased/pr-432.v2.yml
+++ b/changelog/@unreleased/pr-432.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+improvement:
+  description: Support Java 16 for GraalVM 21.1.0 and greater
+  links:
+    - https://github.com/palantir/gradle-graal/pull/432

--- a/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
@@ -104,7 +104,7 @@ public class DownloadGraalTask extends DefaultTask {
     }
 
     private String render(String pattern) {
-        final String computedJavaVersion = GraalVersionUtil.isGraalVersionGreatherThan19_3(graalVersion.get())
+        final String computedJavaVersion = GraalVersionUtil.isGraalVersionGreaterOrEqualThan(graalVersion.get(), 19, 3)
                 ? "java" + javaVersion.get()
                 : ""; // for GraalVM >= 19.3 the naming contains java8 or java11
         return pattern.replaceAll("\\[url\\]", downloadBaseUrl.get())

--- a/src/main/java/com/palantir/gradle/graal/GraalExtension.java
+++ b/src/main/java/com/palantir/gradle/graal/GraalExtension.java
@@ -44,7 +44,7 @@ public class GraalExtension {
     private static final String DOWNLOAD_BASE_URL_GRAAL_19_3 =
             "https://github.com/graalvm/graalvm-ce-builds/" + "releases/download/";
     private static final String DEFAULT_GRAAL_VERSION = "20.2.0";
-    private static final List<String> SUPPORTED_JAVA_VERSIONS = Arrays.asList("11", "8");
+    private static final List<String> SUPPORTED_JAVA_VERSIONS = Arrays.asList("16", "11", "8");
     private static final String DEFAULT_JAVA_VERSION = "8";
 
     private final Property<String> downloadBaseUrl;
@@ -215,7 +215,7 @@ public class GraalExtension {
 
     public final Provider<String> getGraalDirectoryName() {
         return providerFactory.provider(() -> {
-            if (GraalVersionUtil.isGraalVersionGreatherThan19_3(graalVersion.get())) {
+            if (GraalVersionUtil.isGraalVersionGreaterOrEqualThan(graalVersion.get(), 19, 3)) {
                 return "graalvm-ce-java" + javaVersion.get() + "-" + graalVersion.get();
             }
             return "graalvm-ce-" + graalVersion.get();
@@ -223,7 +223,11 @@ public class GraalExtension {
     }
 
     private String getDefaultDownloadBaseUrl() {
-        if (GraalVersionUtil.isGraalVersionGreatherThan19_3(graalVersion.get())) {
+        if (javaVersion.get().equals("16")
+                && !GraalVersionUtil.isGraalVersionGreaterOrEqualThan(graalVersion.get(), 21, 1)) {
+            throw new GradleException(
+                    "Unsupported GraalVM version " + graalVersion.get() + " for Java 16, needs >= 21.1.0.");
+        } else if (GraalVersionUtil.isGraalVersionGreaterOrEqualThan(graalVersion.get(), 19, 3)) {
             return DOWNLOAD_BASE_URL_GRAAL_19_3;
         } else if (!javaVersion.get().equals("8")) {
             throw new GradleException("Unsupported Java version for GraalVM version.");

--- a/src/main/java/com/palantir/gradle/graal/GraalVersionUtil.java
+++ b/src/main/java/com/palantir/gradle/graal/GraalVersionUtil.java
@@ -17,12 +17,12 @@
 package com.palantir.gradle.graal;
 
 public final class GraalVersionUtil {
-    public static boolean isGraalVersionGreatherThan19_3(String graalVersion) {
+    public static boolean isGraalVersionGreaterOrEqualThan(String graalVersion, int majorVersion, int minorVersion) {
         try {
             final String[] versionSplit = graalVersion.split("\\.", -1);
-            final int majorVersion = Integer.valueOf(versionSplit[0]);
-            final int minorVersion = Integer.valueOf(versionSplit[1]);
-            return majorVersion > 19 || (majorVersion == 19 && minorVersion >= 3);
+            final int majorVersion0 = Integer.valueOf(versionSplit[0]);
+            final int minorVersion0 = Integer.valueOf(versionSplit[1]);
+            return majorVersion0 > majorVersion || (majorVersion0 == majorVersion && minorVersion0 >= minorVersion);
         } catch (NumberFormatException ignored) {
             return false;
         }

--- a/src/test/groovy/com/palantir/gradle/graal/GradleExtensionSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleExtensionSpec.groovy
@@ -86,6 +86,26 @@ class GradleExtensionSpec extends ProjectSpec {
         extension.getGraalDirectoryName().get() =~ "graalvm-ce-java11-19.3.0"
     }
 
+    def 'extension should throw exception for graalVersion 21.0.0 and Java version 16'() {
+        when:
+        extension.javaVersion("16")
+        extension.graalVersion("21.0.0")
+        extension.getDownloadBaseUrl().get()
+
+        then:
+        thrown GradleException
+    }
+
+    def 'extension returns the correct Graal download URL and directory name for Java version 16 and graalVersion 21.1.0'() {
+        when:
+        extension.javaVersion("16")
+        extension.graalVersion("21.1.0")
+
+        then:
+        extension.getDownloadBaseUrl().get() =~ "https://github.com/graalvm/graalvm-ce-builds/releases/download/"
+        extension.getGraalDirectoryName().get() =~ "graalvm-ce-java16-21.1.0"
+    }
+
     def 'extension should throw exception for unsupported Java version'() {
         when:
         extension.javaVersion("12")

--- a/src/test/groovy/com/palantir/gradle/graal/GradleVersionUtilSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleVersionUtilSpec.groovy
@@ -23,16 +23,26 @@ import spock.lang.Specification
 class GradleVersionUtilSpec extends Specification {
     def 'should detect Graal version 19.2.0 is not 19.3+'() {
         expect:
-        !GraalVersionUtil.isGraalVersionGreatherThan19_3("19.2.0")
+        !GraalVersionUtil.isGraalVersionGreaterOrEqualThan("19.2.0", 19, 3)
     }
 
-    def 'should detect Graal version 19.3.0 is not 19.3+'() {
+    def 'should detect Graal version 19.3.0 is 19.3+'() {
         expect:
-        GraalVersionUtil.isGraalVersionGreatherThan19_3("19.3.0")
+        GraalVersionUtil.isGraalVersionGreaterOrEqualThan("19.3.0", 19, 3)
     }
 
     def 'should detect Graal version empty is not 19.3+'() {
         expect:
-        !GraalVersionUtil.isGraalVersionGreatherThan19_3("")
+        !GraalVersionUtil.isGraalVersionGreaterOrEqualThan("", 19, 3)
+    }
+
+    def 'should detect Graal version 21.1.0 is 21.1+'() {
+        expect:
+        GraalVersionUtil.isGraalVersionGreaterOrEqualThan("21.1.0", 21, 1)
+    }
+
+    def 'should detect Graal version 21.0.0 is not 21.1+'() {
+        expect:
+        !GraalVersionUtil.isGraalVersionGreaterOrEqualThan("21.0.0", 21, 1)
     }
 }


### PR DESCRIPTION
## Before this PR
No support for Java 16 in the latest Graal version.

## After this PR
Implements support for Java 16 as Graal 21.1.0 is compatible with it,
see https://www.infoq.com/news/2021/05/graalvm-21-1-supports-jdk16/

The download URL is the same as with Java 11 so this change should make
it work. It can be downloaded manually at https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java16-windows-amd64-21.1.0.zip

In addition to these changes, this pull request also refactors
`isGraalVersionGreaterThan19_3` to support checks against 21.1 and also
includes `Equal` in the name as the previous name is a misnomer as it's
actually checking for "greater or equal than" instead of just "greater
than".

## Possible downsides?
None that I know of
