### PR TITLE
Support Java 17 for GraalVM 21.3.0

### DIFF
--- a/src/main/java/com/palantir/gradle/graal/GraalExtension.java
+++ b/src/main/java/com/palantir/gradle/graal/GraalExtension.java
@@ -44,7 +44,7 @@ public class GraalExtension {
     private static final String DOWNLOAD_BASE_URL_GRAAL_19_3 =
             "https://github.com/graalvm/graalvm-ce-builds/" + "releases/download/";
     private static final String DEFAULT_GRAAL_VERSION = "20.2.0";
-    private static final List<String> SUPPORTED_JAVA_VERSIONS = Arrays.asList("16", "11", "8");
+    private static final List<String> SUPPORTED_JAVA_VERSIONS = Arrays.asList("17", "16", "11", "8");
     private static final String DEFAULT_JAVA_VERSION = "8";
 
     private final Property<String> downloadBaseUrl;
@@ -223,7 +223,11 @@ public class GraalExtension {
     }
 
     private String getDefaultDownloadBaseUrl() {
-        if (javaVersion.get().equals("16")
+        if (javaVersion.get().equals("17")
+                && !GraalVersionUtil.isGraalVersionGreaterOrEqualThan(graalVersion.get(), 21, 3)) {
+            throw new GradleException(
+                    "Unsupported GraalVM version " + graalVersion.get() + " for Java 17, needs >= 21.3.0.");
+        } else if (javaVersion.get().equals("16")
                 && !GraalVersionUtil.isGraalVersionGreaterOrEqualThan(graalVersion.get(), 21, 1)) {
             throw new GradleException(
                     "Unsupported GraalVM version " + graalVersion.get() + " for Java 16, needs >= 21.1.0.");

--- a/src/test/groovy/com/palantir/gradle/graal/GradleExtensionSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/graal/GradleExtensionSpec.groovy
@@ -106,6 +106,26 @@ class GradleExtensionSpec extends ProjectSpec {
         extension.getGraalDirectoryName().get() =~ "graalvm-ce-java16-21.1.0"
     }
 
+    def 'extension should throw exception for graalVersion 21.1.0 and Java version 17'() {
+        when:
+        extension.javaVersion("17")
+        extension.graalVersion("21.1.0")
+        extension.getDownloadBaseUrl().get()
+
+        then:
+        thrown GradleException
+    }
+
+    def 'extension returns the correct Graal download URL and directory name for Java version 17 and graalVersion 21.3.0'() {
+        when:
+        extension.javaVersion("17")
+        extension.graalVersion("21.3.0")
+
+        then:
+        extension.getDownloadBaseUrl().get() =~ "https://github.com/graalvm/graalvm-ce-builds/releases/download/"
+        extension.getGraalDirectoryName().get() =~ "graalvm-ce-java17-21.3.0"
+    }
+
     def 'extension should throw exception for unsupported Java version'() {
         when:
         extension.javaVersion("12")


### PR DESCRIPTION
## Before this PR

No support for Java 17 in the latest Graal version 21.3.0.

## After this PR

Equivalent of https://github.com/palantir/gradle-graal/pull/432/
but for GraalVM 21.3.0 instead of 21.1.0.

## Possible downsides?
None that I know of