### PR TITLE
Support for Graal Dev builds

### DIFF
--- a/src/main/java/com/palantir/gradle/graal/ExtractGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/ExtractGraalTask.java
@@ -84,22 +84,25 @@ public class ExtractGraalTask extends DefaultTask {
         } else {
             // ideally this would be a CopyTask, but through Gradle 4.9 CopyTask fails to correctly extract symlinks
             project.exec(spec -> {
-                spec.executable("tar");
-                spec.args("-xzf", inputArchiveFile.getAbsolutePath());
-                spec.workingDir(versionedCacheDir);
-            });
+                        spec.executable("tar");
+                        spec.args("-xzf", inputArchiveFile.getAbsolutePath());
+                        spec.workingDir(versionedCacheDir);
+                    })
+                    .assertNormalExitValue();
         }
 
         File nativeImageExecutable = getExecutable("native-image");
         if (!nativeImageExecutable.isFile()) {
             project.exec(spec -> {
-                File graalUpdateExecutable = getExecutable("gu");
-                if (!graalUpdateExecutable.isFile()) {
-                    throw new IllegalStateException("Failed to find Graal update binary: " + graalUpdateExecutable);
-                }
-                spec.executable(graalUpdateExecutable.getAbsolutePath());
-                spec.args("install", "native-image");
-            });
+                        File graalUpdateExecutable = getExecutable("gu");
+                        if (!graalUpdateExecutable.isFile()) {
+                            throw new IllegalStateException(
+                                    "Failed to find Graal update binary: " + graalUpdateExecutable);
+                        }
+                        spec.executable(graalUpdateExecutable.getAbsolutePath());
+                        spec.args("install", "native-image");
+                    })
+                    .assertNormalExitValue();
         }
     }
 

--- a/src/main/java/com/palantir/gradle/graal/GraalVersionUtil.java
+++ b/src/main/java/com/palantir/gradle/graal/GraalVersionUtil.java
@@ -28,5 +28,18 @@ public final class GraalVersionUtil {
         }
     }
 
+    public static boolean isGraalRcVersion(String graalVersion) {
+        return graalVersion.startsWith("1.0.0-rc");
+    }
+
+    public static boolean isGraalDevVersion(String graalVersion) {
+        return graalVersion.contains("-dev-");
+    }
+
+    // 22.1.0-dev-20220314_2252 -> 22.1.0-dev
+    public static String cutDevSignature(String graalVersion) {
+        return graalVersion.substring(0, graalVersion.indexOf("-dev") + 4);
+    }
+
     private GraalVersionUtil() {}
 }


### PR DESCRIPTION
## Before this PR
There was no way to download dev builds of Graal VM, test versions like 22.1.0-dev-20220314_2252 were not supported

## After this PR
Dev builds are resolving correctly and download the artifacts from https://github.com/graalvm/graalvm-ce-dev-builds/releases
The dev builds structure is fully supported
Closes #374

## Possible downsides?
None

