### PR TITLE
Support aarch64

### DIFF
--- a/changelog/@unreleased/pr-469.v2.yml
+++ b/changelog/@unreleased/pr-469.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Support aarch64 architectures
+  links:
+  - https://github.com/palantir/gradle-graal/pull/469

--- a/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
+++ b/src/main/java/com/palantir/gradle/graal/DownloadGraalTask.java
@@ -133,6 +133,8 @@ public class DownloadGraalTask extends DefaultTask {
         switch (Platform.architecture()) {
             case AMD64:
                 return "amd64";
+            case AARCH64:
+                return "aarch64";
             default:
                 throw new IllegalStateException("No GraalVM support for " + Platform.architecture());
         }

--- a/src/main/java/com/palantir/gradle/graal/Platform.java
+++ b/src/main/java/com/palantir/gradle/graal/Platform.java
@@ -29,6 +29,7 @@ public final class Platform {
 
     public enum Architecture {
         AMD64,
+        AARCH64,
         UNKNOWN
     }
 
@@ -46,7 +47,9 @@ public final class Platform {
 
     public static Architecture architecture() {
         String arch = System.getProperty("os.arch");
-        if (arch.contains("64")) {
+        if (arch.contains("aarch64")) {
+            return Architecture.AARCH64;
+        } else if (arch.contains("64")) {
             return Architecture.AMD64;
         }
         return Architecture.UNKNOWN;


### PR DESCRIPTION
## Before this PR

Addresses #468 -- plugin not respecting arm64 architectures

## After this PR
==COMMIT_MSG==
Support downloading of aarch64 builds of graal
==COMMIT_MSG==

## Possible downsides?
Users of aarch64 may now receive aarch64 graal builds instead of amd64 builds, which _may_ cause issues, though presumably graal team have identified and fixed said issues before releasing builds targeting aarch64.