### PR TITLE
README: Fix the link to native-image build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Configure this plugin and its wrappers around GraalVM tools through the `graal` 
 **`native-image` controls**
 * `outputName`: the name to use for the image output
 * `mainClass`: the main class entry-point for the image to run
-* `option`: additional native-image options (see https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/Options.md)
+* `option`: additional [native-image build options](https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/BuildOptions.md)
 
 Local GraalVM Tooling Cache
 ---------------------------


### PR DESCRIPTION
## Before this PR

Broken link to Graal docs.

## After this PR

Fixed link to Graal docs.

## Possible downsides?

I cannot think of any.

