### PR TITLE
refactor: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/src/main/java/com/palantir/gradle/graal/BaseGraalCompileTask.java
+++ b/src/main/java/com/palantir/gradle/graal/BaseGraalCompileTask.java
@@ -182,7 +182,7 @@ public abstract class BaseGraalCompileTask extends DefaultTask {
             // delayed environment variable expansion via !
             cmdArgs.add("/V:ON");
             cmdArgs.add("/c");
-            cmdArgs.add("\"" + startCmd  + "\"");
+            cmdArgs.add("\"" + startCmd + "\"");
             spec.setExecutable("cmd.exe");
             spec.setArgs(cmdArgs);
         }

--- a/src/main/java/com/palantir/gradle/graal/BaseGraalCompileTask.java
+++ b/src/main/java/com/palantir/gradle/graal/BaseGraalCompileTask.java
@@ -182,7 +182,7 @@ public abstract class BaseGraalCompileTask extends DefaultTask {
             // delayed environment variable expansion via !
             cmdArgs.add("/V:ON");
             cmdArgs.add("/c");
-            cmdArgs.add("\"" + startCmd.toString() + "\"");
+            cmdArgs.add("\"" + startCmd  + "\"");
             spec.setExecutable("cmd.exe");
             spec.setArgs(cmdArgs);
         }


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:939647443 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (1)
<!-- What's wrong with the current state of the world and why change it now? -->
Removing this `toString` call removes noise because a developer has less code to understand.
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Remove unnecessary toString call in BaseGraalCompilerTask
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

A developer could not understand that string concatenation calls the `toString` for objects. I hope this is never the case, but this is the only downside. There is no other unneeded `toString` call in your project according to Qodana/IntelliJ

